### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](https://github.com/home-assistant/brands/raw/b4a168b9af282ef916e120d31091ecd5e3c35e66/core_integrations/adaptive_lighting/icon.png)
 
-_Try out this code by adding https://github.com/basnijholt/adaptive-lighting to your custom repos in HACS and install it!_
+_Try out this code by adding https://github.com/basnijholt/adaptive-lighting to your custom repos in [HACS (Home Assistant Community Store)](https://hacs.xyz/) and install it!_
 *This `custom_component` is also being added to `core`, see [this PR](https://github.com/home-assistant/core/pull/40626), although it might take months before it makes it in.*
 
 The `adaptive_lighting` platform changes the settings of your lights throughout the day.


### PR DESCRIPTION
Added a link to HACS to make installation easier for HA neophytes like myself. 

HA has many parts with sub acronyms. Providing a link to HACS makes it clearer that HACS is not part of the base install. 