### PR TITLE
Add xy and hs as alternative color modes to detect color capabilities

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -40,6 +40,8 @@ from homeassistant.components.light import (
     is_on,
     COLOR_MODE_RGB,
     COLOR_MODE_RGBW,
+    COLOR_MODE_HS,
+    COLOR_MODE_XY,
     COLOR_MODE_COLOR_TEMP,
     COLOR_MODE_BRIGHTNESS,
     ATTR_SUPPORTED_COLOR_MODES,
@@ -393,6 +395,12 @@ def _supported_features(hass: HomeAssistant, light: str):
         # comment https://github.com/basnijholt/adaptive-lighting/issues/112#issuecomment-836944011
         supported.add("brightness")
     if COLOR_MODE_RGBW in supported_color_modes:
+        supported.add("color")
+        supported.add("brightness")  # see above url
+    if COLOR_MODE_XY in supported_color_modes:
+        supported.add("color")
+        supported.add("brightness")  # see above url
+    if COLOR_MODE_HS in supported_color_modes:
         supported.add("color")
         supported.add("brightness")  # see above url
     if COLOR_MODE_COLOR_TEMP in supported_color_modes:


### PR DESCRIPTION
Fixes #148

IKEA lights don't list rgb as color_mode, although the service call accepts rgb as attributes. This way, xy and hs are also recognized as color capable.