### PR TITLE
Default `lights` of the `apply` service

### DIFF
--- a/custom_components/adaptive_lighting/services.yaml
+++ b/custom_components/adaptive_lighting/services.yaml
@@ -5,7 +5,7 @@ apply:
       description: entity_id of the Adaptive Lighting switch.
       example: switch.adaptive_lighting_default
     lights:
-      description: entity_id(s) of lights.
+      description: "entity_id(s) of lights, default: lights of the switch"
       example: light.bedroom_ceiling
     transition:
       description: Transition of the lights.

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -322,7 +322,7 @@ async def async_setup_entry(
     platform.async_register_entity_service(
         SERVICE_APPLY,
         {
-            vol.Required(CONF_LIGHTS): cv.entity_ids,
+            vol.Optional(CONF_LIGHTS, default=switch._lights): cv.entity_ids,  # pylint: disable=protected-access
             vol.Optional(
                 CONF_TRANSITION,
                 default=switch._initial_transition,  # pylint: disable=protected-access


### PR DESCRIPTION
The apply service is meant to apply the adaptive lighting parameters to a specific set of light(s). This set of lights need to be passed to the service, even though each Adaptive Lighting switch already has this list configured on itself. While having the flexibility to apply to some, it also might be useful to apply to all lights that the switch manages.

This patch makes the lights paramater optional and defaults it to the lights configured on the corresponding configuration entry of the switch being called.