### PR TITLE
Fix tuple expression in type annotation

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1074,7 +1074,7 @@ class SunLightSettings:
 
         def calculate_noon_and_midnight(
                 sunset: datetime.datetime, sunrise: datetime.datetime
-        ) -> (datetime.datetime, datetime.datetime):
+        ) -> Tuple[datetime.datetime, datetime.datetime]:
             middle = abs(sunset - sunrise) / 2
             if sunset > sunrise:
                 noon = sunrise + middle


### PR DESCRIPTION
Pylance said:
```
Tuple expression not allowed in type annotation
  Use Tuple[T1, ..., Tn] to indicate a tuple type or Union[T1, T2] to indicate a union type
```