### PR TITLE
Fix missing light entities in options list 

### DIFF
--- a/custom_components/adaptive_lighting/config_flow.py
+++ b/custom_components/adaptive_lighting/config_flow.py
@@ -14,7 +14,7 @@ from .const import (  # pylint: disable=unused-import
     NONE_STR,
     VALIDATION_TUPLES,
 )
-from .switch import _supported_features
+from .switch import _supported_features, validate
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,6 +82,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Handle options flow."""
         conf = self.config_entry
+        data = validate(conf)
         if conf.source == config_entries.SOURCE_IMPORT:
             return self.async_show_form(step_id="init", data_schema=None)
         errors = {}
@@ -95,6 +96,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             for light in self.hass.states.async_entity_ids("light")
             if _supported_features(self.hass, light)
         ]
+        for configured_light in data[CONF_LIGHTS]:
+            if not configured_light in all_lights:
+                all_lights.append(configured_light)
         to_replace = {CONF_LIGHTS: cv.multi_select(sorted(all_lights))}
 
         options_schema = {}


### PR DESCRIPTION
When using the GUI to set options, if a light entity, which was previously configured, is no longer available, then it won't show up in the dropdown list, and causes the validation to fail.  

Validation fails with this error:
![image](https://user-images.githubusercontent.com/24459240/198472372-caddc38a-d1ef-4e75-b5f6-6403e6120637.png)

This failure means there is no way to de-select the light entity, or change any options under this condition.

This PR compares the list of configured lights, to the all_lights variable, and if any are missing, appends them to all_lights.  This allows the user to de-select the light, and make changes to the options.

Will resolve the following issues:
https://github.com/basnijholt/adaptive-lighting/issues/349
https://github.com/basnijholt/adaptive-lighting/issues/287
https://github.com/basnijholt/adaptive-lighting/issues/278