### PR TITLE
Add credits to circadian lighting by @claytonjn

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -338,6 +338,15 @@
       "contributions": [
         "translation"
       ]
+    },
+    {
+      "login": "claytonjn",
+      "name": "Clayton Nummer",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3850252?v=4",
+      "profile": "https://github.com/claytonjn",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -199,7 +199,11 @@ These graphs were generated using the values calculated by the Adaptive Lighting
 ##### Brightness:
 ![cl_brightness|690x130](https://community-home-assistant-assets.s3.dualstack.us-west-2.amazonaws.com/original/3X/5/8/58ebd994b62a8b1abfb3497a5288d923ff4e2330.PNG)
 
-## Contributors
+# Credits
+
+This integration was originally based on the great work in [hass-circadian_lighting](https://github.com/claytonjn/hass-circadian_lighting) by @claytonjn from [6a919ae](https://github.com/claytonjn/hass-circadian_lighting/tree/6a919ae9dadc9103b91b50d8df812b5b86bb9fcd).
+
+# Contributors
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-36-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-37-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 ![Version](https://img.shields.io/github/v/release/basnijholt/adaptive-lighting?style=for-the-badge)
 
@@ -257,6 +257,7 @@ This integration was originally based on the great work in [hass-circadian_light
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/awashingmachine"><img src="https://avatars.githubusercontent.com/u/79043726?v=4?s=100" width="100px;" alt="awashingmachine"/><br /><sub><b>awashingmachine</b></sub></a><br /><a href="#translation-awashingmachine" title="Translation">🌍</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/claytonjn"><img src="https://avatars.githubusercontent.com/u/3850252?v=4?s=100" width="100px;" alt="Clayton Nummer"/><br /><sub><b>Clayton Nummer</b></sub></a><br /><a href="https://github.com/basnijholt/adaptive-lighting/commits?author=claytonjn" title="Code">💻</a></td>
     </tr>
   </tbody>
   <tfoot>


### PR DESCRIPTION
Crediting @claytonjn should have been present since the start.

It wasn't included because originally this code was written as a Pull Request to Home Assistant core (https://github.com/home-assistant/core/pull/40626) and the `README` served as the documentation page.

edit: turns out there was already mention there.