### PR TITLE
Updated optional status for lights in service

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ adaptive_lighting:
 | Service data attribute | Optional | Description                                                                                  |
 | ---------------------- | -------- | -------------------------------------------------------------------------------------------- |
 | `entity_id`            | no       | The `entity_id` of the switch with the settings to apply.                                    |
-| `lights`               | no       | A light (or list of lights) to apply the settings to.                                        |
+| `lights`               | yes      | A light (or list of lights) to apply the settings to.                                        |
 | `transition`           | yes      | The number of seconds for the transition.                                                    |
 | `adapt_brightness`     | yes      | Whether to change the brightness of the light or not.                                        |
 | `adapt_color`          | yes      | Whether to adapt the color on supporting lights.                                             |


### PR DESCRIPTION
@basnijholt thank you for this repo!! I wanted to propose a small tweak to the readme. While implementing `adaptive_lighting.**apply**` in automations, I've noticed that listing the `lights` isn't required. For instance, if I have an adaptive lighting entity called `adaptive_lighting.office`, I can condition a motion sensor trigger with the following action successfully:

    service: adaptive_lighting.apply
    data:
      entity_id: switch.adaptive_lighting_office
      turn_on_lights: true