### PR TITLE
Added change_sunlight_settings service call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+README.md

--- a/custom_components/adaptive_lighting/const.py
+++ b/custom_components/adaptive_lighting/const.py
@@ -59,6 +59,10 @@ SERVICE_SET_MANUAL_CONTROL = "set_manual_control"
 CONF_MANUAL_CONTROL = "manual_control"
 SERVICE_APPLY = "apply"
 CONF_TURN_ON_LIGHTS = "turn_on_lights"
+SERVICE_CHANGE_SUNLIGHT_SETTINGS = "change_sunlight_settings"
+CONF_USE_CONFIG_DEFAULTS = "use_config_defaults"
+CONF_USE_ACTUAL_SUNRISE_TIME = "use_actual_sunrise_time"
+CONF_USE_ACTUAL_SUNSET_TIME = "use_actual_sunset_time"
 
 CONF_ADAPT_DELAY, DEFAULT_ADAPT_DELAY = "adapt_delay", 0
 TURNING_OFF_DELAY = 5

--- a/custom_components/adaptive_lighting/services.yaml
+++ b/custom_components/adaptive_lighting/services.yaml
@@ -34,3 +34,100 @@ set_manual_control:
     lights:
       description: entity_id(s) of lights, if not specified, all lights in the switch are selected.
       example: light.bedroom_ceiling
+change_sunlight_settings:
+  description: Reinitializes sunlight settings with new values for the specific switch
+  fields:
+    entity_id:
+      description: entity_id of the Adaptive Lighting switch.
+      example: switch.adaptive_lighting_default
+      required: true
+      selector:
+        entity:
+          domain: switch
+    use_config_defaults:
+      description: "Any setting in this service call that isn't EXPLICITLY defined will either default back to the config (True) or the previous values (False)"
+      example: false
+      required: false
+      default: false
+      selector:
+        boolean:
+    use_actual_sunrise_time:
+      description: "Erase manual handling of the sunrise time (if any) and calculates the actual sunrise"
+      example: false
+      required: false
+      default: false
+      selector:
+        boolean:
+    use_actual_sunset_time:
+      description: "Erase manual handling of the sunset time (if any) and calculates the actual sunset"
+      example: false
+      required: false
+      default: false
+      selector:
+        boolean:
+    max_brightness:
+      description: "max_brightness, in %"
+      example: 100
+      required: false
+      selector:
+        text:
+    max_color_temp:
+      description: max_color_temp, in Kelvin
+      example: 5500
+      required: false
+      selector:
+        text:
+    min_brightness:
+      description: min_brightness, in %
+      example: 1
+      required: false
+      selector:
+        text:
+    min_color_temp:
+      description: min_color_temp, in Kelvin
+      example: 2000
+      required: false
+      selector:
+        text:
+    sleep_brightness:
+      description: sleep_brightness, in %
+      example: 1
+      required: false
+      selector:
+        text:
+    sleep_color_temp:
+      description: sleep_color_temp, in Kelvin
+      example: 1000
+      required: false
+      selector:
+        text:
+    sunrise_offset:
+      description: sunrise_offset, in +/- seconds (HH:MM:SS)
+      example: 02:00:00
+      required: false
+      selector:
+        text:
+    sunrise_time:
+      description: sunrise_time, in 'HH:MM:SS' format (if 'None', it uses the actual sunrise time at your location)
+      example: 07:00:00
+      required: false
+      selector:
+        time:
+    sunset_offset:
+      description: sunset_offset, in +/- seconds (HH:MM:SS)
+      example: 04:00:00
+      required: false
+      selector:
+        text:
+    sunset_time:
+      description: sunset_time, in 'HH:MM:SS' format (if 'None', it uses the actual sunset time at your location)
+      example: 06:00:00
+      required: false
+      selector:
+        time:
+    transition:
+      description: transition, in seconds
+      example: 1
+      required: false
+      selector:
+        text:

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -316,6 +316,8 @@ async def handle_change_sunlight_settings(switch: AdaptiveSwitch, service_call: 
     min_color_temp=sun_light_settings.min_color_temp if not CONF_MIN_COLOR_TEMP in data else data[CONF_MIN_COLOR_TEMP]
     sleep_brightness=sun_light_settings.sleep_brightness if not CONF_SLEEP_BRIGHTNESS in data else data[CONF_SLEEP_BRIGHTNESS]
     sleep_color_temp=sun_light_settings.sleep_color_temp if not CONF_SLEEP_COLOR_TEMP in data else data[CONF_SLEEP_COLOR_TEMP]
+    sleep_rgb_color=sun_light_settings.sleep_rgb_color if not CONF_SLEEP_RGB_COLOR in data else data[CONF_SLEEP_RGB_COLOR]
+    sleep_rgb_or_color_temp=sun_light_settings.sleep_rgb_or_color_temp if not CONF_SLEEP_RGB_OR_COLOR_TEMP in data else data[CONF_SLEEP_RGB_OR_COLOR_TEMP]
     sunrise_offset=sun_light_settings.sunrise_offset if not CONF_SUNRISE_OFFSET in data else data[CONF_SUNRISE_OFFSET]
     if use_actual_sunrise_time:
         if CONF_SUNRISE_TIME in data:
@@ -326,6 +328,7 @@ async def handle_change_sunlight_settings(switch: AdaptiveSwitch, service_call: 
         sunrise_time = None
     else:
         sunrise_time=sun_light_settings.sunrise_time if not CONF_SUNRISE_TIME in data else data[CONF_SUNRISE_TIME]
+    max_sunrise_time=sun_light_settings.max_sunrise_time if not CONF_MAX_SUNRISE_TIME in data else data[CONF_MAX_SUNRISE_TIME]
     sunset_offset=sun_light_settings.sunset_offset if not CONF_SUNSET_OFFSET in data else data[CONF_SUNSET_OFFSET]
     if use_actual_sunset_time:
         if CONF_SUNSET_TIME in data:
@@ -336,6 +339,7 @@ async def handle_change_sunlight_settings(switch: AdaptiveSwitch, service_call: 
         sunset_time = None
     else:
         sunset_time=sun_light_settings.sunset_time if not CONF_SUNSET_TIME in data else data[CONF_SUNSET_TIME]
+    min_sunset_time=sun_light_settings.min_sunset_time if not CONF_MIN_SUNSET_TIME in data else data[CONF_MIN_SUNSET_TIME]
     transition=sun_light_settings.transition if not CONF_TRANSITION in data else data[CONF_TRANSITION]
 
     object.__setattr__(switch, '_sun_light_settings', SunLightSettings(  # pylint: disable=protected-access
@@ -347,10 +351,14 @@ async def handle_change_sunlight_settings(switch: AdaptiveSwitch, service_call: 
         min_color_temp=min_color_temp,
         sleep_brightness=sleep_brightness,
         sleep_color_temp=sleep_color_temp,
+        sleep_rgb_color=sleep_rgb_color,
+        sleep_rgb_or_color_temp=sleep_rgb_or_color_temp,
         sunrise_offset=sunrise_offset,
         sunrise_time=sunrise_time,
+        max_sunrise_time=max_sunrise_time,
         sunset_offset=sunset_offset,
         sunset_time=sunset_time,
+        min_sunset_time=min_sunset_time,
         time_zone=hass.config.time_zone,
         transition=transition,
     ))
@@ -719,10 +727,14 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
             min_color_temp=data[CONF_MIN_COLOR_TEMP],
             sleep_brightness=data[CONF_SLEEP_BRIGHTNESS],
             sleep_color_temp=data[CONF_SLEEP_COLOR_TEMP],
+            sleep_rgb_color=data[CONF_SLEEP_RGB_COLOR],
+            sleep_rgb_or_color_temp=data[CONF_SLEEP_RGB_OR_COLOR_TEMP],
             sunrise_offset=data[CONF_SUNRISE_OFFSET],
             sunrise_time=data[CONF_SUNRISE_TIME],
+            max_sunrise_time=data[CONF_MAX_SUNRISE_TIME],
             sunset_offset=data[CONF_SUNSET_OFFSET],
             sunset_time=data[CONF_SUNSET_TIME],
+            min_sunset_time=data[CONF_MIN_SUNSET_TIME],
             time_zone=self.hass.config.time_zone,
             transition=data[CONF_TRANSITION],
         )


### PR DESCRIPTION
My first python project. New service call 'change_sunlight_settings'. allows scripts/automations to change sunlight settings at any time, without requiring a restart of Home Assistant.

Cons:

- Yes I'm modifying a frozen dataclass and that's probably not what the devs had in mind when they originally constructed it.
Pros:

- this service call doesn't require any modifications to the original code at all, allowing for easy addition to the main project.
- Relatively lightweight

Use cases:
I work very odd hours that require me to wake up at a different time everyday, so I was looking for a way to adapt my lights throughout the day based on whenever my Home Assistant alarm runs. Unfortunately after a lot of searching it seemed like this simple feature didn't exist anywhere, so I decided to make it myself. I know next to nothing about python so my priorities were:

- Getting the damn thing to work
- Trying my best to 'add' the feature instead of rewrite the entire code, therefore allowing me to merge future updates into my fork.
- Usability & Flexibility.

Check out the readme.md on https://github.com/th3w1zard1/adaptive-lighting for more information.