### PR TITLE
Fixes `detect_non_ha_changes` not respecting significant changes during a transition

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -878,7 +878,7 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         # If there is a transition, mark the time we started adapting this light
         # then the next time we start adapting, compare to the last timestamp. See #447
         if transition and transition != 0:
-            self._transition_timestamp = perf_counter()
+            self._transition_timer = perf_counter()
             self._last_transition = transition
         if not self._separate_turn_on_commands:
             await turn_on(service_data)


### PR DESCRIPTION
See #447 for information.

A very simple fix. `adaptive-lighting` needs to wait for a prior adapt transition to finish before continuing through `_adapt_light`.
This PR achieves that end goal by simply calling `await asyncio.sleep(1.2)` in a while loop until the transition finishes.

This PR also makes #417 entirely obsolete, as the interval being greater than transitions would no longer be an issue.