### PR TITLE
Try installing extra deps such that bcrypt and cryptography can be installed in arm/v7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ FROM python:3.11-buster
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     git \
+    build-essential libssl-dev libffi-dev python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Clone home-assistant/core


### PR DESCRIPTION
Docker build is currently failing