### PR TITLE
Use ENTRYPOINT and CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN pip3 install $(python3 /app/test_dependencies.py) --use-pep517
 
 WORKDIR /core
 
-CMD ["python3", \
+ENTRYPOINT ["python3", \
     # Enable Python development mode
     "-X", "dev", \
     # Run pytest
@@ -59,7 +59,7 @@ CMD ["python3", \
     # Print logs in color
     "--color=yes", \
     # Print a count of test results in the console
-    "-o", "console_output_style=count", \
-    # Run tests in the 'tests/components/adaptive_lighting' directory
-    "tests/components/adaptive_lighting" \
-    ]
+    "-o", "console_output_style=count"]
+
+# Run tests in the 'tests/components/adaptive_lighting' directory
+CMD ["tests/components/adaptive_lighting"]


### PR DESCRIPTION
This will run all the tests by default but also allow custom function calls.

For example:
```bash
docker run -v $(pwd):/app basnijholt/adaptive-lighting:latest tests/components/adaptive_lighting/test_switch.py::test_adaptive_lighting_time_zones_and_sun_settings
```
will only run the `test_adaptive_lighting_time_zones_and_sun_settings` test.

This also allows to pass in multiple command line arguments for pytest, such as filtering of the logs (@th3w1zard1). I will have to figure out how to do that exactly though.