### PR TITLE
(master renames to main) Sync main branch to master

### DIFF
--- a/.github/workflows/main-to-master-sync.yml
+++ b/.github/workflows/main-to-master-sync.yml
@@ -1,0 +1,22 @@
+name: Sync Main to Master
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        ref: main
+        fetch-depth: 0
+
+    - name: Push changes to master
+      run: |
+        git checkout -b master
+        git push origin +master


### PR DESCRIPTION
I renamed the default branch. I am adding this CI job to automatically sync back the changes to the master branch.