### PR TITLE
Autoreset_Control_Time - small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The YAML and frontend configuration methods support all of the options listed be
 | `separate_turn_on_commands`    | Use separate `light.turn_on` calls for color and brightness, needed for some light types. 🔀                                                                                     | `False`        | `bool`                               |
 | `send_split_delay`             | Wait time (milliseconds) between commands when using `separate_turn_on_commands`. Helps ensure correct handling. ⏲️                                                             | `0`            | `int` 0-10000                        |
 | `adapt_delay`                  | Wait time (seconds) between light turn on and Adaptive Lighting applying changes. Helps avoid flickering. ⏲️                                                                    | `0`            | `float > 0`                          |
-| `autoreset_control_seconds`    | Automatically reset the manual control after a number of seconds. Set to 0 to disable. ⏲️                                                                                       | `0`            | `int` 0-604800                       |
+| `autoreset_control_seconds`    | Automatically reset the manual control after a number of seconds. Set to 0 to disable. ⏲️                                                                                       | `0`            | `int` 0-31536000                     |
 
 <!-- END_OUTPUT -->
 

--- a/custom_components/adaptive_lighting/const.py
+++ b/custom_components/adaptive_lighting/const.py
@@ -228,7 +228,7 @@ VALIDATION_TUPLES = [
     (
         CONF_AUTORESET_CONTROL,
         DEFAULT_AUTORESET_CONTROL,
-        int_between(0, 7 * 24 * 60 * 60),  # 7 days max
+        int_between(0, 365 * 24 * 60 * 60),  # 1 year max
     ),
 ]
 

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -822,6 +822,7 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         self._adapt_delay = data[CONF_ADAPT_DELAY]
         self._send_split_delay = data[CONF_SEND_SPLIT_DELAY]
         self._auto_reset_manual_control_time = data[CONF_AUTORESET_CONTROL]
+        self._expand_light_groups()  # update manual control timers.
         _loc = get_astral_location(self.hass)
         if isinstance(_loc, tuple):
             # Astral v2.2

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -822,7 +822,7 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         self._adapt_delay = data[CONF_ADAPT_DELAY]
         self._send_split_delay = data[CONF_SEND_SPLIT_DELAY]
         self._auto_reset_manual_control_time = data[CONF_AUTORESET_CONTROL]
-        self._expand_light_groups()  # update manual control timers.
+        self._expand_light_groups()  # updates manual control timers
         _loc = get_astral_location(self.hass)
         if isinstance(_loc, tuple):
             # Astral v2.2


### PR DESCRIPTION
Timers now get updated when using `change_switch_settings`

I changed the max number of seconds from 7 days to one year as in my opinion it's unnecessary to limit as I stated in the original PR but you're the boss 😄 


