### PR TITLE
Actually corrected the docker tests this time.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -5,17 +5,15 @@ Alternatively, you can use the provided Docker image to run the tests locally.
 
 To run the tests using the Docker image, navigate to the `adaptive-lighting` repo folder and execute the following command:
 
-Linux or MacOS:
-
+Linux / MacOS / Windows PowerShell:
 ```bash
-docker run -v $(pwd):/app basnijholt/adaptive-lighting:latest
+docker run -v ${PWD}:/app basnijholt/adaptive-lighting:latest
 ```
 
-Windows:
-
-```bash
-docker run -v %cd%:/app basnijholt/adaptive-lighting:latest
-```
+- In windows command prompt, the command is:
+  ```bash
+  docker run -v %cd%:/app basnijholt/adaptive-lighting:latest
+  ```
 
 This command will download the Docker image from [the adaptive-lighting Docker Hub repo](https://hub.docker.com/r/basnijholt/adaptive-lighting) and run the tests.
 


### PR DESCRIPTION
Turns out windows 10 and 11 can't use `$(pwd):/app` OR `%cd%:/app` in PowerShell (which replaced cmd prompt), so I looked up the docs and made the necessary changes (again, sorry!)

These changes have been tested on all terminal environments except macOS. The docs say it'll work there but I don't have a mac.