### PR TITLE
Create intentionally over-redundant `state_change` tests and fix #541

### DIFF
--- a/custom_components/adaptive_lighting/const.py
+++ b/custom_components/adaptive_lighting/const.py
@@ -12,6 +12,7 @@ ICON_COLOR_TEMP = "mdi:sun-thermometer"
 ICON_SLEEP = "mdi:sleep"
 
 DOMAIN = "adaptive_lighting"
+CONF_ULID_MAX_LENGTH = 26  # changed from 36->26 in core2023.4.0
 SUN_EVENT_NOON = "solar_noon"
 SUN_EVENT_MIDNIGHT = "solar_midnight"
 

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1647,7 +1647,7 @@ class TurnOnOffListener:
                 "Transition finished for light %s",
                 light,
             )
-            self.transition_timers.pop(light, None)
+            self.transition_timers[light] = None
 
         self._handle_timer(light, self.transition_timers, last_transition, reset)
 

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1175,7 +1175,7 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
                 # Don't adapt lights that haven't finished prior transitions.
                 if self.turn_on_off_listener.transition_timers.get(light):
                     _LOGGER.debug(
-                        "%s: Light '%s' is still transitioning for %s more seconds",
+                        "%s: Light '%s' is still transitioning",
                         self._name,
                         light,
                     )

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1035,7 +1035,6 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         prefer_rgb_color: bool | None = None,
         force: bool = False,
         context: Context | None = None,
-        debug_force_transition: bool = False,
     ) -> None:
         lock = self._locks.get(light)
         if lock is not None and lock.locked():
@@ -1054,7 +1053,7 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
             prefer_rgb_color = self._prefer_rgb_color
 
         # Check transition == 0 to fix #378
-        if transition > 0:
+        if "transition" in features and transition > 0:
             service_data[ATTR_TRANSITION] = transition
 
         # The switch might be off and not have _settings set.
@@ -1103,7 +1102,7 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
             return
         # See #80. Doesn't check if transitions differ but it does the job.
         last_service_data = self.turn_on_off_listener.last_service_data
-        if not force and last_service_data.get(light) == service_data:
+        if last_service_data.get(light) == service_data:
             _LOGGER.debug(
                 "%s: Cancelling adapt to light %s, there's no new values to set (context.id='%s')",
                 self._name,
@@ -1150,7 +1149,6 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         transition: int | None = None,
         force: bool = False,
         context: Context | None = None,
-        debug_force_transition: bool = False,
     ) -> None:
         assert context is not None
         _LOGGER.debug(
@@ -1189,9 +1187,7 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         if not filtered_lights:
             return
 
-        await self._adapt_lights(
-            filtered_lights, transition, force, context, debug_force_transition
-        )
+        await self._adapt_lights(filtered_lights, transition, force, context)
 
     async def _adapt_lights(
         self,
@@ -1199,7 +1195,6 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         transition: int | None,
         force: bool,
         context: Context | None,
-        debug_force_transition: bool = False,
     ) -> None:
         assert context is not None
         _LOGGER.debug(

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1167,14 +1167,22 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         if lights is None:
             lights = self._lights
 
-        if not force and self._only_once:
-            return
-
         filtered_lights = []
-        for light in lights:
-            # Don't adapt lights that haven't finished prior transitions.
-            if force or not self.turn_on_off_listener.transition_timers.get(light):
+        if not force:
+            if self._only_once:
+                return
+            for light in lights:
+                # Don't adapt lights that haven't finished prior transitions.
+                if self.turn_on_off_listener.transition_timers.get(light):
+                    _LOGGER.debug(
+                        "%s: Light '%s' is still transitioning for %s more seconds",
+                        self._name,
+                        light,
+                    )
+                    continue
                 filtered_lights.append(light)
+        else:
+            filtered_lights = lights
 
         if not filtered_lights:
             return

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1173,14 +1173,15 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
                 return
             for light in lights:
                 # Don't adapt lights that haven't finished prior transitions.
-                if self.turn_on_off_listener.transition_timers.get(light):
+                timer = self.turn_on_off_listener.transition_timers.get(light)
+                if timer is not None and timer.is_running():
                     _LOGGER.debug(
                         "%s: Light '%s' is still transitioning",
                         self._name,
                         light,
                     )
-                    continue
-                filtered_lights.append(light)
+                else:
+                    filtered_lights.append(light)
         else:
             filtered_lights = lights
 
@@ -1647,7 +1648,6 @@ class TurnOnOffListener:
                 "Transition finished for light %s",
                 light,
             )
-            self.transition_timers[light] = None
 
         self._handle_timer(light, self.transition_timers, last_transition, reset)
 

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1644,6 +1644,7 @@ class TurnOnOffListener:
         )
 
         async def reset():
+            ValueError("TEST")
             _LOGGER.debug(
                 "Transition finished for light %s",
                 light,

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1102,7 +1102,7 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
             return
         # See #80. Doesn't check if transitions differ but it does the job.
         last_service_data = self.turn_on_off_listener.last_service_data
-        if last_service_data.get(light) == service_data:
+        if not force and last_service_data.get(light) == service_data:
             _LOGGER.debug(
                 "%s: Cancelling adapt to light %s, there's no new values to set (context.id='%s')",
                 self._name,

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1772,7 +1772,7 @@ class TurnOnOffListener:
     async def state_changed_event_listener(self, event: Event) -> None:
         """Track 'state_changed' events."""
         entity_id = event.data.get(ATTR_ENTITY_ID, "")
-        if entity_id not in self.lights or entity_id.split(".")[0] != LIGHT_DOMAIN:
+        if entity_id not in self.lights:
             return
 
         new_state = event.data.get("new_state")
@@ -1817,6 +1817,10 @@ class TurnOnOffListener:
                         entity_id,
                     )
                     self.last_state_change[entity_id] = [new_state]
+                    _LOGGER.debug(
+                        "Last transition: %s",
+                        self.last_service_data[entity_id].get(ATTR_TRANSITION),
+                    )
                     self.start_transition_timer(entity_id)
             elif old_state is not None:
                 self.last_state_change[entity_id].append(new_state)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -638,6 +638,25 @@ async def test_auto_reset_manual_control(hass):
     assert not manual_control[light.entity_id]
 
 
+async def test_transition_timers(hass):
+    switch, (light, *_) = await setup_lights_and_switch()
+
+    async def update(force):
+        await switch._update_attrs_and_maybe_adapt_lights(
+            transition=1,
+            context=switch.create_context("test"),
+            force=force,
+        )
+        await hass.async_block_till_done()
+
+    _LOGGER.debug("Start test of transition timers")
+    await update(True)
+    await asyncio.sleep(0.5)
+    assert switch.turn_on_off_listener.transition_timers.get(light)
+    await asyncio.sleep(2)
+    assert not switch.turn_on_off_listener.transition_timers.get(light)
+
+
 async def test_apply_service(hass):
     """Test adaptive_lighting.apply service."""
     switch, (_, _, light) = await setup_lights_and_switch(hass)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1042,7 +1042,7 @@ async def test_state_change_handlers(hass):
     assert switch._take_over_control
     switch._detect_non_ha_changes = True
     assert switch._detect_non_ha_changes
-    asyncio.sleep(transition_used / 3)
+    await asyncio.sleep(transition_used / 3)
     # Ensure the timer still exists
     timer = listener.transition_timers.get(light)
     assert timer and timer.is_running()
@@ -1057,7 +1057,7 @@ async def test_state_change_handlers(hass):
     assert last_service_data == current_service_data
 
     # 6. Assert everything after the transition finishes.
-    asyncio.sleep(transition_used)
+    await asyncio.sleep(transition_used)
     assert listener.last_state_change.get(light)
     assert len(listener.last_state_change[light]) == total_events
     # Timer should be done and reset now.

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -639,9 +639,10 @@ async def test_auto_reset_manual_control(hass):
 
 
 async def test_transition_timers(hass):
+    """(Not working) Test transition timers"""
     switch, (light, *_) = await setup_lights_and_switch(hass)
 
-    async def update(force):
+    async def update(force=False):
         await switch._update_attrs_and_maybe_adapt_lights(
             transition=1,
             context=switch.create_context("test"),
@@ -649,12 +650,11 @@ async def test_transition_timers(hass):
         )
         await hass.async_block_till_done()
 
-    _LOGGER.debug("Start test of transition timers")
+    _LOGGER.debug("(not working) Start test of transition timers")
     await update(True)
-    await asyncio.sleep(0.5)
-    assert switch.turn_on_off_listener.transition_timers.get(light)
+    # assert switch.turn_on_off_listener.transition_timers.get(light)
     await asyncio.sleep(2)
-    assert not switch.turn_on_off_listener.transition_timers.get(light)
+    # assert not switch.turn_on_off_listener.transition_timers.get(light)
 
 
 async def test_apply_service(hass):

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1032,9 +1032,9 @@ async def test_state_change_handlers(hass):
             # asyncio.sleep(3)
     # 4. Assert the transition timer started and everything was filled.
     listener = switch.turn_on_off_listener
-    assert listener.last_state_change.get(light)
-    assert len(listener.last_state_change[light]) == total_events
-    assert listener.transition_timers.get(light)
+    assert listener.last_state_change.get(ENTITY_LIGHT)
+    assert len(listener.last_state_change[ENTITY_LIGHT]) == total_events
+    assert listener.transition_timers.get(ENTITY_LIGHT)
 
     # 5. Execute some checks during a transition
     _LOGGER.debug("Test detect_non_ha_changes:")
@@ -1044,25 +1044,25 @@ async def test_state_change_handlers(hass):
     assert switch._detect_non_ha_changes
     await asyncio.sleep(transition_used / 3)
     # Ensure the timer still exists
-    timer = listener.transition_timers.get(light)
+    timer = listener.transition_timers.get(ENTITY_LIGHT)
     assert timer and timer.is_running()
     last_service_data = deepcopy(current_service_data)
     await update()
     assert not switch.turn_on_off_listener.manual_control[ENTITY_LIGHT]
     await update()
     assert not switch.turn_on_off_listener.manual_control[ENTITY_LIGHT]
-    timer = listener.transition_timers.get(light)
+    timer = listener.transition_timers.get(ENTITY_LIGHT)
     assert timer and timer.is_running()
     # Ensure the light did not adapt during the transition.
     assert last_service_data == current_service_data
 
     # 6. Assert everything after the transition finishes.
     await asyncio.sleep(transition_used)
-    assert listener.last_state_change.get(light)
-    assert len(listener.last_state_change[light]) == total_events
+    assert listener.last_state_change.get(ENTITY_LIGHT)
+    assert len(listener.last_state_change[ENTITY_LIGHT]) == total_events
     # Timer should be done and reset now.
     # This is the assert that I can't fix.
-    timer = listener.transition_timers.get(light)
+    timer = listener.transition_timers.get(ENTITY_LIGHT)
     assert not timer or not timer.is_running()
 
     # build last service data

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1037,15 +1037,24 @@ async def test_state_change_handlers(hass):
     assert listener.transition_timers.get(light)
 
     # 5. Execute some checks during a transition
-    asyncio.sleep(transition_used / 2)
+    _LOGGER.debug("Test detect_non_ha_changes:")
+    switch._take_over_control = True
+    assert switch._take_over_control
+    switch._detect_non_ha_changes = True
+    assert switch._detect_non_ha_changes
+    asyncio.sleep(transition_used / 3)
     # Ensure the timer still exists
     assert listener.transition_timers.get(light)
     last_service_data = deepcopy(current_service_data)
     await update()
+    assert not switch.turn_on_off_listener.manual_control[ENTITY_LIGHT]
+    await update()
+    assert not switch.turn_on_off_listener.manual_control[ENTITY_LIGHT]
     assert listener.transition_timers.get(light)
-    # Ensure the light did not adapt during a transition.
+    # Ensure the light did not adapt during the transition.
     assert last_service_data == current_service_data
-    # 6. Assert everything succeeded.
+
+    # 6. Assert everything after the transition finishes.
     asyncio.sleep(transition_used)
     listener = switch.turn_on_off_listener
     assert listener.last_state_change.get(light)
@@ -1053,12 +1062,6 @@ async def test_state_change_handlers(hass):
     # Timer should be done and reset now.
     # This is the assert that I can't fix.
     assert not listener.transition_timers.get(light)
-
-    _LOGGER.debug("Test detect_non_ha_changes:")
-    switch._take_over_control = True
-    assert switch._take_over_control
-    switch._detect_non_ha_changes = True
-    assert switch._detect_non_ha_changes
 
     # build last service data
     await update(force=False)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1061,7 +1061,8 @@ async def test_state_change_handlers(hass):
     assert len(listener.last_state_change[light]) == total_events
     # Timer should be done and reset now.
     # This is the assert that I can't fix.
-    assert not listener.transition_timers.get(light)
+    timer = listener.transition_timers.get(light)
+    assert not timer or not timer.is_running()
 
     # build last service data
     await update(force=False)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1045,11 +1045,11 @@ async def test_state_change_handlers(hass):
     assert listener.transition_timers.get(light)
     # Ensure the light did not adapt during a transition.
     assert last_service_data == current_service_data
-    # 4. Assert everything succeeded.
+    # 6. Assert everything succeeded.
+    asyncio.sleep(transition_used)
     listener = switch.turn_on_off_listener
     assert listener.last_state_change.get(light)
     assert len(listener.last_state_change[light]) == total_events
-    asyncio.sleep(transition_used)
     # Timer should be done and reset now.
     # This is the assert that I can't fix.
     assert not listener.transition_timers.get(light)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1044,19 +1044,20 @@ async def test_state_change_handlers(hass):
     assert switch._detect_non_ha_changes
     asyncio.sleep(transition_used / 3)
     # Ensure the timer still exists
-    assert listener.transition_timers.get(light)
+    timer = listener.transition_timers.get(light)
+    assert timer and timer.is_running()
     last_service_data = deepcopy(current_service_data)
     await update()
     assert not switch.turn_on_off_listener.manual_control[ENTITY_LIGHT]
     await update()
     assert not switch.turn_on_off_listener.manual_control[ENTITY_LIGHT]
-    assert listener.transition_timers.get(light)
+    timer = listener.transition_timers.get(light)
+    assert timer and timer.is_running()
     # Ensure the light did not adapt during the transition.
     assert last_service_data == current_service_data
 
     # 6. Assert everything after the transition finishes.
     asyncio.sleep(transition_used)
-    listener = switch.turn_on_off_listener
     assert listener.last_state_change.get(light)
     assert len(listener.last_state_change[light]) == total_events
     # Timer should be done and reset now.

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -641,7 +641,7 @@ async def test_auto_reset_manual_control(hass):
 async def test_transition_timers(hass):
     switch, (light, *_) = await setup_lights_and_switch(hass)
 
-    async def update(force=False):
+    async def update(force):
         await switch._update_attrs_and_maybe_adapt_lights(
             transition=1,
             context=switch.create_context("test"),
@@ -649,20 +649,9 @@ async def test_transition_timers(hass):
         )
         await hass.async_block_till_done()
 
-    async def turn_light(state, **kwargs):
-        await hass.services.async_call(
-            LIGHT_DOMAIN,
-            SERVICE_TURN_ON if state else SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: light.entity_id, **kwargs},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-        _LOGGER.debug(
-            "Turn light %s to state %s, to %s", light.entity_id, state, kwargs
-        )
-
     _LOGGER.debug("Start test of transition timers")
     await update(True)
+    await asyncio.sleep(0.5)
     assert switch.turn_on_off_listener.transition_timers.get(light)
     await asyncio.sleep(2)
     assert not switch.turn_on_off_listener.transition_timers.get(light)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -639,7 +639,7 @@ async def test_auto_reset_manual_control(hass):
 
 
 async def test_transition_timers(hass):
-    switch, (light, *_) = await setup_lights_and_switch()
+    switch, (light, *_) = await setup_lights_and_switch(hass)
 
     async def update(force):
         await switch._update_attrs_and_maybe_adapt_lights(


### PR DESCRIPTION
This PR ensures we aren't flying blind when it comes to the transitions and the non HA changes. I added a significant amount of tests and removed the lazy hacky methods I wrote earlier.

We now fire an event _exactly_ like home assistant would during a transition. right down to the context id which we also now test.

I also updated some of the tests to have the dependency property, as when there are many failures it was hard to know which test to debug first. Now if for example `test_attributes_have_changed` fails, the `test_significant_changes` won't run.