### PR TITLE
New services `adaptive_lighting.turn_on` `turn_off` `toggle` with optional switch/lights args

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ TODO: ...
 
 <!-- START_OUTPUT -->
 <!-- THIS CONTENT IS AUTOMATICALLY GENERATED -->
+| Service data attribute   | Description                                                                                                                     | Required   | Type                 |
+|:-------------------------|:--------------------------------------------------------------------------------------------------------------------------------|:-----------|:---------------------|
+| `entity_id`              | The `entity_id` of the switch with the settings to apply. 📝                                                                     | ✅          | list of `entity_id`s |
+| `lights`                 | A light (or list of lights) to apply the settings to. 💡                                                                         | ❌          | list of `entity_id`s |
+| `switch_type`            | Which switch to target in this service call. Options: "main" (default, targets the main switch), "sleep", "brightness", "color" | ✅          | str                  |
 
 <!-- END_OUTPUT -->
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The `adaptive_lighting.manual_control` event is fired when a light is marked as 
   - [:memo: Options](#memo-options)
   - [:hammer_and_wrench: Services](#hammer_and_wrench-services)
     - [`adaptive_lighting.apply`](#adaptive_lightingapply)
+    - [`adaptive_lighting.turn_on`, `adaptive_lighting.turn_off`, `adaptive_lighting.toggle`](#adaptive_lightingturn_on-adaptive_lightingturn_off-adaptive_lightingtoggle)
     - [`adaptive_lighting.set_manual_control`](#adaptive_lightingset_manual_control)
     - [`adaptive_lighting.change_switch_settings`](#adaptive_lightingchange_switch_settings)
 - [:robot: Automation examples](#robot-automation-examples)
@@ -176,6 +177,25 @@ adaptive_lighting:
 | `turn_on_lights`         | Whether to turn on lights that are currently off. 🔆                                  | ❌          | bool                 |
 
 <!-- END_OUTPUT -->
+
+
+#### `adaptive_lighting.turn_on`, `adaptive_lighting.turn_off`, `adaptive_lighting.toggle`
+
+`adaptive_lighting.turn_on`, `adaptive_lighting.turn_off`, `adaptive_lighting.toggle` turn Adaptive Lighting on or off.
+
+TODO: ...
+
+<!-- START_CODE -->
+<!-- from homeassistant.components.adaptive_lighting import _docs_helpers -->
+<!-- print(_docs_helpers.generate_turn_on_markdown_table()) -->
+<!-- END_CODE -->
+
+<!-- START_OUTPUT -->
+<!-- THIS CONTENT IS AUTOMATICALLY GENERATED -->
+
+<!-- END_OUTPUT -->
+
+
 #### `adaptive_lighting.set_manual_control`
 
 `adaptive_lighting.set_manual_control` can mark (or unmark) whether a light is "manually controlled", meaning that when a light has `manual_control`, the light is not adapted.

--- a/custom_components/adaptive_lighting/_docs_helpers.py
+++ b/custom_components/adaptive_lighting/_docs_helpers.py
@@ -42,6 +42,8 @@ def _type_to_str(type_: Any) -> str:
     """Convert a (voluptuous) type to a string."""
     if type_ == cv.entity_ids:
         return "list of `entity_id`s"
+    elif type_ == cv.string:
+        return "str"
     elif type_ in (bool, int, float, str):
         return f"`{type_.__name__}`"
     elif type_ == cv.boolean:

--- a/custom_components/adaptive_lighting/_docs_helpers.py
+++ b/custom_components/adaptive_lighting/_docs_helpers.py
@@ -9,6 +9,7 @@ from .const import (
     DOCS,
     DOCS_APPLY,
     DOCS_MANUAL_CONTROL,
+    SERVICE_TOGGLE_SCHEMA,
     SET_MANUAL_CONTROL_SCHEMA,
     VALIDATION_TUPLES,
     apply_service_schema,
@@ -108,6 +109,10 @@ def _generate_service_markdown_table(
 
 def generate_apply_markdown_table():
     return _generate_service_markdown_table(apply_service_schema(), DOCS_APPLY)
+
+
+def generate_turn_on_markdown_table():
+    return _generate_service_markdown_table(SERVICE_TOGGLE_SCHEMA, DOCS_APPLY)
 
 
 def generate_set_manual_control_markdown_table():

--- a/custom_components/adaptive_lighting/const.py
+++ b/custom_components/adaptive_lighting/const.py
@@ -211,12 +211,12 @@ DOCS[CONF_WHICH_SWITCH] = (
     "Which switch to target in this service call. Options: "
     '"main" (default, targets the main switch), "sleep", "brightness", "color"'
 )
-DOCS[
-    SERVICE_TURN_ON
-] = "Turn on an Adaptive Lighting main/sleep/brightness/color switch"
-DOCS[
-    SERVICE_TURN_OFF
-] = "Turn off an Adaptive Lighting main/sleep/brightness/color switch"
+DOCS[SERVICE_TURN_ON] = (
+    "Turn on an Adaptive Lighting" " main/sleep/brightness/color switch"
+)
+DOCS[SERVICE_TURN_OFF] = (
+    "Turn off an Adaptive Lighting" " main/sleep/brightness/color switch"
+)
 DOCS[SERVICE_TOGGLE] = "Toggle an Adaptive Lighting main/sleep/brightness/color switch"
 
 TURNING_OFF_DELAY = 5

--- a/custom_components/adaptive_lighting/const.py
+++ b/custom_components/adaptive_lighting/const.py
@@ -1,7 +1,12 @@
 """Constants for the Adaptive Lighting integration."""
 
 from homeassistant.components.light import VALID_TRANSITION
-from homeassistant.const import CONF_ENTITY_ID
+from homeassistant.const import (
+    CONF_ENTITY_ID,
+    SERVICE_TOGGLE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
 from homeassistant.helpers import selector
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -201,6 +206,19 @@ DOCS[CONF_USE_DEFAULTS] = (
     'documented defaults), or "configuration" (reverts to switch config defaults). ⚙️'
 )
 
+CONF_WHICH_SWITCH, DEFAULT_WHICH_SWITCH = "switch_type", "main"
+DOCS[CONF_WHICH_SWITCH] = (
+    "Which switch to target in this service call. Options: "
+    '"main" (default, targets the main switch), "sleep", "brightness", "color"'
+)
+DOCS[
+    SERVICE_TURN_ON
+] = "Turn on an Adaptive Lighting main/sleep/brightness/color switch"
+DOCS[
+    SERVICE_TURN_OFF
+] = "Turn off an Adaptive Lighting main/sleep/brightness/color switch"
+DOCS[SERVICE_TOGGLE] = "Toggle an Adaptive Lighting main/sleep/brightness/color switch"
+
 TURNING_OFF_DELAY = 5
 
 DOCS_MANUAL_CONTROL = {
@@ -338,6 +356,14 @@ def apply_service_schema(initial_transition: int = 1):
         }
     )
 
+
+SERVICE_TOGGLE_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_ENTITY_ID): cv.entity_ids,
+        vol.Optional(CONF_LIGHTS, default=[]): cv.entity_ids,
+        vol.Optional(CONF_WHICH_SWITCH): cv.string,
+    }
+)
 
 SET_MANUAL_CONTROL_SCHEMA = vol.Schema(
     {

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -484,15 +484,15 @@ async def async_setup_entry(
             data,
         )
         switches = _get_switches_from_service_call(hass, service_call)
-        these_switches = []  # CONF_WHICH_SWITCH == "main" is default
         if data[CONF_WHICH_SWITCH] == "sleep":
-            these_switches = [s.sleep_mode_switch for s in switches]
+            switches = [s.sleep_mode_switch for s in switches]
         elif data[CONF_WHICH_SWITCH] == "brightness":
-            these_switches = [s.adapt_brightness_switch for s in switches]
+            switches = [s.adapt_brightness_switch for s in switches]
         elif data[CONF_WHICH_SWITCH] == "color":
-            these_switches = [s.adapt_color_switch for s in switches]
-        _LOGGER.debug("Turning on switches [%s]", these_switches)
-        for switch in these_switches:
+            switches = [s.adapt_color_switch for s in switches]
+
+        _LOGGER.debug("Turning on switches [%s]", switches)
+        for switch in switches:
             await switch.async_turn_on()
 
     @callback
@@ -504,15 +504,14 @@ async def async_setup_entry(
             data,
         )
         switches = _get_switches_from_service_call(hass, service_call)
-        these_switches = []  # CONF_WHICH_SWITCH == "main" is default
         if data[CONF_WHICH_SWITCH] == "sleep":
-            these_switches = [s.sleep_mode_switch for s in switches]
+            switches = [s.sleep_mode_switch for s in switches]
         elif data[CONF_WHICH_SWITCH] == "brightness":
-            these_switches = [s.adapt_brightness_switch for s in switches]
+            switches = [s.adapt_brightness_switch for s in switches]
         elif data[CONF_WHICH_SWITCH] == "color":
-            these_switches = [s.adapt_color_switch for s in switches]
-        _LOGGER.debug("Turning off switches [%s]", these_switches)
-        for switch in these_switches:
+            switches = [s.adapt_color_switch for s in switches]
+        _LOGGER.debug("Turning off switches [%s]", switches)
+        for switch in switches:
             await switch.async_turn_off()
 
     @callback
@@ -524,15 +523,14 @@ async def async_setup_entry(
             data,
         )
         switches = _get_switches_from_service_call(hass, service_call)
-        these_switches = []  # CONF_WHICH_SWITCH == "main" is default
         if data[CONF_WHICH_SWITCH] == "sleep":
-            these_switches = [s.sleep_mode_switch for s in switches]
+            switches = [s.sleep_mode_switch for s in switches]
         elif data[CONF_WHICH_SWITCH] == "brightness":
-            these_switches = [s.adapt_brightness_switch for s in switches]
+            switches = [s.adapt_brightness_switch for s in switches]
         elif data[CONF_WHICH_SWITCH] == "color":
-            these_switches = [s.adapt_color_switch for s in switches]
-        _LOGGER.debug("Toggling switches [%s]", these_switches)
-        for switch in these_switches:
+            switches = [s.adapt_color_switch for s in switches]
+        _LOGGER.debug("Toggling switches [%s]", switches)
+        for switch in switches:
             if switch.is_on:
                 await switch.async_turn_off()
             else:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -53,7 +53,6 @@ from homeassistant.components.light import (
     ATTR_XY_COLOR,
 )
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from homeassistant.components.light import SERVICE_TURN_OFF
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 import homeassistant.config as config_util
 from homeassistant.config_entries import ConfigEntryState

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -25,6 +25,7 @@ from homeassistant.components.adaptive_lighting.const import (
     CONF_TRANSITION,
     CONF_TURN_ON_LIGHTS,
     CONF_USE_DEFAULTS,
+    CONF_WHICH_SWITCH,
     DEFAULT_MAX_BRIGHTNESS,
     DEFAULT_NAME,
     DEFAULT_SLEEP_BRIGHTNESS,
@@ -64,6 +65,8 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PLATFORM,
     EVENT_STATE_CHANGED,
+    SERVICE_TOGGLE,
+    SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
@@ -1244,6 +1247,82 @@ async def test_area(hass):
         switch.turn_on_off_listener.last_service_data,
     )
     assert light.entity_id not in switch.turn_on_off_listener.last_service_data
+
+
+@pytest.mark.dependency(depends=GLOBAL_TEST_DEPENDENCIES)
+async def test_switch_turn_on_off_toggle(hass):
+    """Test adaptive_lighting.change_switch_settings service."""
+    switch, (_, _, light) = await setup_lights_and_switch(hass)
+    entity_id = switch.entity_id
+    assert entity_id not in switch._lights
+
+    async def turn_on(which: str, **kwargs):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                CONF_WHICH_SWITCH: which,
+                **kwargs,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    async def turn_off(which: str, **kwargs):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TURN_OFF,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                CONF_WHICH_SWITCH: which,
+                **kwargs,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    async def toggle(which: str, **kwargs):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TOGGLE,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                CONF_WHICH_SWITCH: which,
+                **kwargs,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    # Test sleep
+    await turn_on("sleep")
+    assert switch.sleep_mode_switch.is_on
+    await turn_off("sleep")
+    assert not switch.sleep_mode_switch.is_on
+    await toggle("sleep")
+    assert switch.sleep_mode_switch.is_on
+    # Test brightness
+    await turn_on("brightness")
+    assert switch.adapt_brightness_switch.is_on
+    await turn_off("brightness")
+    assert not switch.adapt_brightness_switch.is_on
+    await toggle("brightness")
+    assert switch.adapt_brightness_switch.is_on
+    # Test color
+    await turn_on("color")
+    assert switch.adapt_color_switch.is_on
+    await turn_off("color")
+    assert not switch.adapt_color_switch.is_on
+    await toggle("color")
+    assert switch.adapt_color_switch.is_on
+    # Test main
+    await turn_on("main")
+    assert switch.is_on
+    await turn_off("main")
+    assert not switch.is_on
+    await toggle("main")
+    assert switch.is_on
 
 
 @pytest.mark.dependency(depends=GLOBAL_TEST_DEPENDENCIES)


### PR DESCRIPTION
Now that we have lookups for our optional lights or switches arguments, I figure some new service calls to support that would be welcome.

Tests are written and everything else in `const.py`

Ran into this problem while trying to modify some of my HASS automations. Mainly the wake-up script as it currently just disables adaptive lighting and does its own transitioning.

With this PR I simply need to call one service:
```
service: adaptive_lighting.turn_off
data:
  lights:
    - light.bedside_lamp
    - light.bedroom_ceilingfan_lights
  switch_type: "sleep"
```