### PR TITLE
Allow more flexibility in service calls

### DIFF
--- a/custom_components/adaptive_lighting/const.py
+++ b/custom_components/adaptive_lighting/const.py
@@ -196,9 +196,9 @@ DOCS[CONF_TURN_ON_LIGHTS] = "Whether to turn on lights that are currently off. �
 SERVICE_CHANGE_SWITCH_SETTINGS = "change_switch_settings"
 CONF_USE_DEFAULTS = "use_defaults"
 DOCS[CONF_USE_DEFAULTS] = (
-    "Sets the default values not specified in this service call. Options: "
+    "Where to autofill config options that are not passed to this service. Options: "
     '"current" (default, retains current values), "factory" (resets to '
-    'documented defaults), or "configuration" (reverts to switch config defaults). ⚙️'
+    'documented defaults), or "configuration" (reverts to original user config). ⚙️'
 )
 
 TURNING_OFF_DELAY = 5
@@ -321,28 +321,36 @@ _DOMAIN_SCHEMA = vol.Schema(
 )
 
 
-def apply_service_schema(initial_transition: int = 1):
-    """Return the schema for the apply service."""
-    return vol.Schema(
-        {
-            vol.Optional(CONF_ENTITY_ID): cv.entity_ids,
-            vol.Optional(CONF_LIGHTS, default=[]): cv.entity_ids,
-            vol.Optional(
-                CONF_TRANSITION,
-                default=initial_transition,
-            ): VALID_TRANSITION,
-            vol.Optional(ATTR_ADAPT_BRIGHTNESS, default=True): cv.boolean,
-            vol.Optional(ATTR_ADAPT_COLOR, default=True): cv.boolean,
-            vol.Optional(CONF_PREFER_RGB_COLOR, default=False): cv.boolean,
-            vol.Optional(CONF_TURN_ON_LIGHTS, default=False): cv.boolean,
-        }
-    )
+SCHEMA_APPLY = vol.Schema(
+    {
+        vol.Optional(CONF_ENTITY_ID): cv.entity_ids,
+        vol.Optional(CONF_LIGHTS, default=[]): cv.entity_ids,
+        vol.Optional(CONF_TRANSITION): VALID_TRANSITION,
+        vol.Optional(ATTR_ADAPT_BRIGHTNESS, default=True): cv.boolean,
+        vol.Optional(ATTR_ADAPT_COLOR, default=True): cv.boolean,
+        vol.Optional(CONF_PREFER_RGB_COLOR, default=False): cv.boolean,
+        vol.Optional(CONF_TURN_ON_LIGHTS, default=False): cv.boolean,
+    }
+)
 
 
-SET_MANUAL_CONTROL_SCHEMA = vol.Schema(
+SCHEMA_SET_MANUAL_CONTROL = vol.Schema(
     {
         vol.Optional(CONF_ENTITY_ID): cv.entity_ids,
         vol.Optional(CONF_LIGHTS, default=[]): cv.entity_ids,
         vol.Optional(CONF_MANUAL_CONTROL, default=True): cv.boolean,
+    }
+)
+
+SCHEMA_CHANGE_SWITCH_SETTINGS = vol.Schema(
+    {
+        vol.Optional(CONF_USE_DEFAULTS): cv.string,
+        vol.Optional(CONF_ENTITY_ID): cv.entity_ids,
+        vol.Required(CONF_LIGHTS, default=[]): [],
+        **{
+            vol.Optional(k): valid
+            for k, _, valid in VALIDATION_TUPLES
+            if k not in [CONF_INTERVAL, CONF_NAME, CONF_LIGHTS]
+        },
     }
 )

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1256,6 +1256,9 @@ async def test_area(hass):
 async def test_change_switch_settings_service(hass):
     """Test adaptive_lighting.change_switch_settings service."""
     switch, (_, _, light) = await setup_lights_and_switch(hass)
+    switch2, (_, light2, _) = await setup_lights_and_switch(
+        hass, {CONF_NAME: "second_switch"}
+    )
     entity_id = light.entity_id
     assert entity_id not in switch._lights
 
@@ -1264,7 +1267,6 @@ async def test_change_switch_settings_service(hass):
             DOMAIN,
             SERVICE_CHANGE_SWITCH_SETTINGS,
             {
-                ATTR_ENTITY_ID: ENTITY_SWITCH,
                 **kwargs,
             },
             blocking=True,
@@ -1273,12 +1275,16 @@ async def test_change_switch_settings_service(hass):
 
     # Test changing sunrise offset
     assert switch._sun_light_settings.sunrise_offset.total_seconds() == 0
-    await change_switch_settings(**{CONF_SUNRISE_OFFSET: 10})
+    await change_switch_settings(
+        **{ATTR_ENTITY_ID: ENTITY_SWITCH, CONF_SUNRISE_OFFSET: 10}
+    )
     assert switch._sun_light_settings.sunrise_offset.total_seconds() == 10
 
     # Test changing max brightness
     assert switch._sun_light_settings.max_brightness == 100
-    await change_switch_settings(**{CONF_MAX_BRIGHTNESS: 50})
+    await change_switch_settings(
+        **{ATTR_ENTITY_ID: ENTITY_SWITCH, CONF_MAX_BRIGHTNESS: 50}
+    )
     assert switch._sun_light_settings.max_brightness == 50
 
     # Test changing to illegal max brightness
@@ -1286,20 +1292,33 @@ async def test_change_switch_settings_service(hass):
         voluptuous.error.MultipleInvalid,
         match="value must be at most 100 for dictionary",
     ):
-        await change_switch_settings(**{CONF_MAX_BRIGHTNESS: 5000})
+        await change_switch_settings(
+            **{ATTR_ENTITY_ID: ENTITY_SWITCH, CONF_MAX_BRIGHTNESS: 5000}
+        )
 
     # Change CONF_MIN_COLOR_TEMP, the factory default is 2000, but setup_lights_and_switch
     # sets it to 2500
     assert switch._sun_light_settings.min_color_temp == 2500
 
     # testing with "factory" should change it to 2000
-    await change_switch_settings(**{CONF_USE_DEFAULTS: "factory"})
+    await change_switch_settings(
+        **{ATTR_ENTITY_ID: ENTITY_SWITCH, CONF_USE_DEFAULTS: "factory"}
+    )
     assert switch._sun_light_settings.min_color_temp == 2000
 
     # testing with "current" should not change things
-    await change_switch_settings(**{CONF_USE_DEFAULTS: "current"})
+    await change_switch_settings(
+        **{ATTR_ENTITY_ID: ENTITY_SWITCH, CONF_USE_DEFAULTS: "current"}
+    )
     assert switch._sun_light_settings.min_color_temp == 2000
 
     # testing with "configuration" should revert back to 2500
-    await change_switch_settings(**{CONF_USE_DEFAULTS: "configuration"})
+    await change_switch_settings(
+        **{ATTR_ENTITY_ID: ENTITY_SWITCH, CONF_USE_DEFAULTS: "configuration"}
+    )
     assert switch._sun_light_settings.min_color_temp == 2500
+
+    # testing with no switches or lights defined.
+    assert switch2._sun_light_settings.max_brightness == 100
+    await change_switch_settings(**{CONF_MAX_BRIGHTNESS: 50})
+    assert switch2._sun_light_settings.max_brightness == 50


### PR DESCRIPTION
This PR removes the following check from service calls:
```
if not lights and not entity_ids in service_call.data:
    raise ValueError(
    "Please inform the developers of your use case."
    " You must currently pass either the lights or the switches."
)
```
That is all. Wait no one more:
- _Service calls now default to `CONF_TRANSITION` instead of `CONF_INITIAL_TRANSITION`_


Why I thought limiting the potential of the service calls just to baby unintentional inputs is beyond me as 5 minutes into trying to use the new service calls I wanted to adapt every switch at once.

Alternatively we could validate an optional argument  `CONF_USE_ALL_ENTITIES: bool` when `False` will output the old errors, `True` will use all switches.

This PR does not modify the 'lights existing in multiple switches' validation.

I did refactor the schemas for some of the `const.py` entries (e.g. they all start with `SCHEMA_` now

