### PR TITLE
Auto update and expand `_lights` class variable in `AdaptiveSwitch` on access

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1702,8 +1702,8 @@ class TurnOnOffListener:
             "Start transition timer of %s seconds for light %s", last_transition, light
         )
 
-        def reset():
-            raise ValueError("TEST")
+        async def reset():
+            ValueError("TEST")
             _LOGGER.debug(
                 "Transition finished for light %s",
                 light,


### PR DESCRIPTION
It seemed arbitrary or unnecessarily picky when `switch.py` would used `_expand_light_groups()` before using `_lights`, now it just auto-expands on each access.

Code also uses `switch._lights` more sparingly and only once per method.

I also added `  # pylint: disable=protected-access` to any function that accessed a class method outside of the class as that seemed to be what we've been going with.