### PR TITLE
ignore `ATTR_TRANSITION` when comparing to `last_service_data`

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1137,10 +1137,12 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         listener = self.turn_on_off_listener
         last_service_data = listener.last_service_data.get(light)
         ignore_fields = {ATTR_TRANSITION}
-        differing_fields = {
-            k for k, _ in last_service_data.items() ^ service_data.items()
-        }
-        if not force and last_service_data and differing_fields == ignore_fields:
+        if (
+            not force
+            and last_service_data
+            and {k for k, _ in last_service_data.items() ^ service_data.items()}
+            == ignore_fields
+        ):
             _LOGGER.debug(
                 "%s: Cancelling adapt to light %s, there's no new values to set (context.id='%s')",
                 self._name,

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1133,12 +1133,16 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         elif "color" in features and adapt_color:
             _LOGGER.debug("%s: Setting rgb_color of light %s", self._name, light)
             service_data[ATTR_RGB_COLOR] = self._settings["rgb_color"]
-
-        context = context or self.create_context("adapt_lights")
-
-        # See #80. Doesn't check if transitions differ but it does the job.
-        last_service_data = self.turn_on_off_listener.last_service_data
-        if not force and last_service_data.get(light) == service_data:
+        # Check if service data differs from the last. See #80.
+        listener = self.turn_on_off_listener
+        last_service_data = listener.last_service_data.get(light)
+        ignore_fields = {ATTR_TRANSITION}
+        if (
+            not force
+            and last_service_data
+            and {k for k, _ in last_service_data.items() ^ service_data.items()}
+            == ignore_fields
+        ):
             _LOGGER.debug(
                 "%s: Cancelling adapt to light %s, there's no new values to set (context.id='%s')",
                 self._name,
@@ -1146,8 +1150,9 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
                 context.id,
             )
             return
-        else:
-            self.turn_on_off_listener.last_service_data[light] = service_data
+        listener.last_service_data[light] = service_data
+
+        context = context or self.create_context("adapt_lights")
 
         async def turn_on(service_data):
             _LOGGER.debug(

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1137,12 +1137,10 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         listener = self.turn_on_off_listener
         last_service_data = listener.last_service_data.get(light)
         ignore_fields = {ATTR_TRANSITION}
-        if (
-            not force
-            and last_service_data
-            and {k for k, _ in last_service_data.items() ^ service_data.items()}
-            == ignore_fields
-        ):
+        differing_fields = {
+            k for k, _ in last_service_data.items() ^ service_data.items()
+        }
+        if not force and last_service_data and differing_fields == ignore_fields:
             _LOGGER.debug(
                 "%s: Cancelling adapt to light %s, there's no new values to set (context.id='%s')",
                 self._name,


### PR DESCRIPTION
- Ignore ATTR_TRANSITION when we compare last_service_data to current.
- Will now skip the check if `force is True`
- Moved new context creation below the check - for the debug logger.