### PR TITLE
support `ATTR_TRANSITION` by default

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -671,6 +671,7 @@ def _supported_features(hass: HomeAssistant, light: str):
         {
             ATTR_MIN_COLOR_TEMP_KELVIN: min_kelvin,
             ATTR_MAX_COLOR_TEMP_KELVIN: max_kelvin,
+            ATTR_TRANSITION: True,
         }
     )
     if supports_colors:


### PR DESCRIPTION
Not sure why it's saying none of my bulbs support transition.