### PR TITLE
fix: lights unexpectedly turn back on after switch-off

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1111,7 +1111,7 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
             context=self.create_context("interval"),
         )
 
-    async def _adapt_light(
+    async def _adapt_light(  # noqa: C901
         self,
         light: str,
         transition: int | None = None,

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1216,12 +1216,9 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         if not self._separate_turn_on_commands:
             await turn_on(service_data)
         else:
-            if (
-                previous_task := self.turn_on_off_listener.split_adaptation_tasks.get(
-                    light
-                )
-            ) is not None:
-                previous_task.cancel()
+            prev_task = self.turn_on_off_listener.split_adaptation_tasks.get(light)
+            if prev_task is not None:
+                prev_task.cancel()
 
             try:
                 task = self.turn_on_off_listener.split_adaptation_tasks[

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1813,6 +1813,9 @@ class TurnOnOffListener:
             self.last_state_change.pop(light, None)
             self.last_service_data.pop(light, None)
 
+            if (task := self.split_adaptation_tasks.get(light)) is not None:
+                task.cancel()
+
     async def turn_on_off_event_listener(self, event: Event) -> None:
         """Track 'light.turn_off' and 'light.turn_on' service calls."""
         domain = event.data.get(ATTR_DOMAIN)
@@ -1854,8 +1857,6 @@ class TurnOnOffListener:
             for eid in entity_ids:
                 self.turn_off_event[eid] = event
                 self.reset(eid)
-                if (task := self.split_adaptation_tasks.get(eid)) is not None:
-                    task.cancel()
 
         elif service == SERVICE_TURN_ON:
             _LOGGER.debug(

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1217,8 +1217,7 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
             await turn_on(service_data)
         else:
             split_tasks = self.turn_on_off_listener.split_adaptation_tasks
-            previous_task = split_tasks.get(light)
-            if previous_task is not None:
+            if (previous_task := split_tasks.get(light)) is not None:
                 previous_task.cancel()
             try:
                 self.split_tasks[light] = asyncio.ensure_future(turn_on_split())

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1199,7 +1199,7 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
                 service_data,
                 context=context,
             )
-        
+
         async def turn_on_split():
             # Could be a list of length 1 or 2
             service_datas = _split_service_data(
@@ -1216,15 +1216,21 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         if not self._separate_turn_on_commands:
             await turn_on(service_data)
         else:
-            if previous_task := self.turn_on_off_listener.split_adaptation_tasks.get(light) is not None:
+            if (
+                previous_task := self.turn_on_off_listener.split_adaptation_tasks.get(
+                    light
+                )
+                is not None
+            ):
                 previous_task.cancel()
-            
+
             try:
-                task = self.turn_on_off_listener.split_adaptation_tasks[light] = asyncio.ensure_future(turn_on_split())
+                task = self.turn_on_off_listener.split_adaptation_tasks[
+                    light
+                ] = asyncio.ensure_future(turn_on_split())
                 await task
             except asyncio.CancelledError:
                 _LOGGER.debug("Split adaptation of %s cancelled", light)
-            
 
     async def _update_attrs_and_maybe_adapt_lights(
         self,

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1216,15 +1216,13 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         if not self._separate_turn_on_commands:
             await turn_on(service_data)
         else:
-            prev_task = self.turn_on_off_listener.split_adaptation_tasks.get(light)
-            if prev_task is not None:
-                prev_task.cancel()
-
+            split_tasks = self.turn_on_off_listener.split_adaptation_tasks
+            previous_task = split_tasks.get(light)
+            if previous_task is not None:
+                previous_task.cancel()
             try:
-                task = self.turn_on_off_listener.split_adaptation_tasks[
-                    light
-                ] = asyncio.ensure_future(turn_on_split())
-                await task
+                self.split_tasks[light] = asyncio.ensure_future(turn_on_split())
+                await self.split_tasks[light]
             except asyncio.CancelledError:
                 _LOGGER.debug("Split adaptation of %s cancelled", light)
 

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1220,8 +1220,8 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
             if (previous_task := split_tasks.get(light)) is not None:
                 previous_task.cancel()
             try:
-                self.split_tasks[light] = asyncio.ensure_future(turn_on_split())
-                await self.split_tasks[light]
+                split_tasks[light] = asyncio.ensure_future(turn_on_split())
+                await split_tasks[light]
             except asyncio.CancelledError:
                 _LOGGER.debug("Split adaptation of %s cancelled", light)
 

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1217,11 +1217,10 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
             await turn_on(service_data)
         else:
             if (
-                (previous_task := self.turn_on_off_listener.split_adaptation_tasks.get(
+                previous_task := self.turn_on_off_listener.split_adaptation_tasks.get(
                     light
-                ))
-                is not None
-            ):
+                )
+            ) is not None:
                 previous_task.cancel()
 
             try:

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1217,9 +1217,9 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
             await turn_on(service_data)
         else:
             if (
-                previous_task := self.turn_on_off_listener.split_adaptation_tasks.get(
+                (previous_task := self.turn_on_off_listener.split_adaptation_tasks.get(
                     light
-                )
+                ))
                 is not None
             ):
                 previous_task.cancel()
@@ -1861,7 +1861,7 @@ class TurnOnOffListener:
             for eid in entity_ids:
                 self.turn_off_event[eid] = event
                 self.reset(eid)
-                if task := self.split_adaptation_tasks.get(eid) is not None:
+                if (task := self.split_adaptation_tasks.get(eid)) is not None:
                     task.cancel()
 
         elif service == SERVICE_TURN_ON:


### PR DESCRIPTION
Cancel ongoing split adaptation commands when lights are turned off to avoid the delayed second half of the command to turn lights back on.

Fixes https://github.com/basnijholt/adaptive-lighting/issues/410#issuecomment-1539788096. There's still a race condition between turn-off and adaptation commands, so it doesn't entirely fix #410. It reduces the likelihood, though (I am testing it locally).