### PR TITLE
fix: 2023.6 compatibility

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,8 +13,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
-        core-version: ["2023.2.5", "2023.3.6", "2023.4.6", "2023.5.2", "dev"]
+        include:
+          - python-version: "3.10"
+            core-version: "2023.2.5"
+          - python-version: "3.10"
+            core-version: "2023.3.6"
+          - python-version: "3.10"
+            core-version: "2023.4.6"
+          - python-version: "3.10"
+            core-version: "2023.5.2"
+          - python-version: "3.11"
+            core-version: "2023.6.0b4"
+          - python-version: "3.11"
+            core-version: "dev"
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -23,7 +23,7 @@ jobs:
           - python-version: "3.10"
             core-version: "2023.5.2"
           - python-version: "3.11"
-            core-version: "2023.6.0"
+            core-version: "2023.6.1"
           - python-version: "3.11"
             core-version: "dev"
     steps:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -23,7 +23,7 @@ jobs:
           - python-version: "3.10"
             core-version: "2023.5.2"
           - python-version: "3.11"
-            core-version: "2023.6.0b4"
+            core-version: "2023.6.0"
           - python-version: "3.11"
             core-version: "dev"
     steps:

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -486,7 +486,7 @@ async def async_setup_entry(
     data[config_entry.entry_id][SWITCH_DOMAIN] = switch
 
     async_add_entities(
-        [switch, sleep_mode_switch, adapt_color_switch, adapt_brightness_switch],
+        [sleep_mode_switch, adapt_color_switch, adapt_brightness_switch, switch],
         update_before_add=True,
     )
 


### PR DESCRIPTION
HA 2023.6 handles adding of a list of entities differently, which breaks testing and reloading AL (updating settings and disabling/enabling the integration). Fix by changing the entity order so that the simple switches are initialized first.

Validated with HA `2023.6.1`.