### PR TITLE
Bail adapting if on event equals off event context

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -2525,8 +2525,11 @@ class AdaptiveLightingManager:
             return False
 
         if off_to_on_event.context.id == on_to_off_event.context.id:
-            # Light was just turned off, and after a update_entity call
-            # it reports as 'on' again with the same context.id.
+            _LOGGER.debug(
+                "just_turned_off: 'on' → 'off' state change has the same context.id as the"
+                " 'off' → 'on' state change for '%s'. This is probably a false positive.",
+                entity_id,
+            )
             return True
 
         id_on_to_off = on_to_off_event.context.id

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -2497,7 +2497,7 @@ class AdaptiveLightingManager:
             and id_off_to_on == turn_on_event.context.id
         )
 
-    async def just_turned_off(  # noqa: PLR0911
+    async def just_turned_off(  # noqa: PLR0911, PLR0912
         self,
         entity_id: str,
     ) -> bool:
@@ -2523,6 +2523,11 @@ class AdaptiveLightingManager:
                 entity_id,
             )
             return False
+
+        if off_to_on_event.context.id == on_to_off_event.context.id:
+            # Light was just turned off, and after a update_entity call
+            # it reports as 'on' again with the same context.id.
+            return True
 
         id_on_to_off = on_to_off_event.context.id
 


### PR DESCRIPTION
Should prevent this (I saw in my logs)
```
2023-08-02 21:49:56.516 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] Detected an 'light.turn_off('['light.philips_go', 'light.bed_led', 'light.bamboo']', transition=10.0)' event with context.id='01H6WVP8RJF4JZ78SFD98YA0RG'
2023-08-02 21:49:56.637 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] Detected an 'on' → 'off' event for 'light.bamboo' with context.id='01H6WVP8RJF4JZ78SFD98YA0RG'
2023-08-02 21:49:56.672 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] Detected an 'on' → 'off' event for 'light.bed_led' with context.id='01H6WVP8RJF4JZ78SFD98YA0RG'
2023-08-02 21:49:56.747 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] Detected an 'on' → 'off' event for 'light.philips_go' with context.id='01H6WVP8RJF4JZ78SFD98YA0RG'
2023-08-02 21:50:00.501 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] Detected a 'light.philips_go' 'state_changed' event: '{'min_color_temp_kelvin': 2000, 'max_color_temp_kelvin': 6666, 'min_mireds': 150, 'max_mireds': 500, 'effect_list': ['blink', 'breathe', 'okay', 'channel_change', 'candle', 'fireplace', 'colorloop', 'finish_effect', 'stop_effect', 'stop_hue_effect'], 'supported_color_modes': ['color_temp', 'xy'], 'color_mode': <ColorMode.XY: 'xy'>, 'brightness': 10, 'hs_color': (0.0, 100.0), 'rgb_color': (255, 0, 0), 'xy_color': (0.701, 0.299), 'friendly_name': 'Philips Go', 'supported_features': <LightEntityFeature.EFFECT|FLASH|TRANSITION: 44>}' with context.id='01H6WVP8RJF4JZ78SFD98YA0RG'
2023-08-02 21:50:00.502 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] Detected an 'off' → 'on' event for 'light.philips_go' with context.id='01H6WVP8RJF4JZ78SFD98YA0RG'
2023-08-02 21:50:00.502 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] is_proactively_adapting_context='False', context_id='01H6WVP8RJF4JZ78SFD98YA0RG'
2023-08-02 21:50:00.502 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] just_turned_off: Waiting with adjusting 'light.philips_go' for 6.240101
2023-08-02 21:50:00.528 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] Detected a 'light.bed_led' 'state_changed' event: '{'min_color_temp_kelvin': 2000, 'max_color_temp_kelvin': 6535, 'min_mireds': 153, 'max_mireds': 500, 'effect_list': ['blink', 'breathe', 'okay', 'channel_change', 'candle', 'fireplace', 'colorloop', 'finish_effect', 'stop_effect', 'stop_hue_effect'], 'supported_color_modes': ['color_temp', 'xy'], 'color_mode': <ColorMode.XY: 'xy'>, 'brightness': 10, 'hs_color': (10.824, 100.0), 'rgb_color': (255, 46, 0), 'xy_color': (0.689, 0.309), 'friendly_name': 'Bed LED', 'supported_features': <LightEntityFeature.EFFECT|FLASH|TRANSITION: 44>}' with context.id='01H6WVP8RJF4JZ78SFD98YA0RG'
2023-08-02 21:50:00.529 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] Detected an 'off' → 'on' event for 'light.bed_led' with context.id='01H6WVP8RJF4JZ78SFD98YA0RG'
2023-08-02 21:50:00.529 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] is_proactively_adapting_context='False', context_id='01H6WVP8RJF4JZ78SFD98YA0RG'
2023-08-02 21:50:00.529 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] just_turned_off: Waiting with adjusting 'light.bed_led' for 6.129017
2023-08-02 21:50:00.561 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] Detected a 'light.bamboo' 'state_changed' event: '{'min_color_temp_kelvin': 2000, 'max_color_temp_kelvin': 6535, 'min_mireds': 153, 'max_mireds': 500, 'effect_list': ['blink', 'breathe', 'okay', 'channel_change', 'candle', 'fireplace', 'colorloop', 'finish_effect', 'stop_effect', 'stop_hue_effect'], 'supported_color_modes': ['color_temp', 'xy'], 'color_mode': <ColorMode.XY: 'xy'>, 'brightness': 10, 'hs_color': (299.434, 83.137), 'rgb_color': (253, 43, 255), 'xy_color': (0.382, 0.159), 'friendly_name': 'Bamboo', 'supported_features': <LightEntityFeature.EFFECT|FLASH|TRANSITION: 44>}' with context.id='01H6WVP8RJF4JZ78SFD98YA0RG'
2023-08-02 21:50:00.562 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] Detected an 'off' → 'on' event for 'light.bamboo' with context.id='01H6WVP8RJF4JZ78SFD98YA0RG'
2023-08-02 21:50:00.562 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] is_proactively_adapting_context='False', context_id='01H6WVP8RJF4JZ78SFD98YA0RG'
2023-08-02 21:50:00.562 DEBUG (MainThread) [custom_components.adaptive_lighting.switch] just_turned_off: Waiting with adjusting 'light.bamboo' for 6.072956
```