### PR TITLE
Protect for None attributes after HA core change

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -710,6 +710,10 @@ def _attributes_have_changed(
     adapt_color: bool,
     context: Context,
 ) -> bool:
+    # 2023-11-19: HA core no longer removes light domain attributes when off
+    # so we must protect for `None` here
+    # see https://github.com/home-assistant/core/pull/101946
+    
     if adapt_color:
         old_attributes, new_attributes = _add_missing_attributes(
             old_attributes,
@@ -718,8 +722,8 @@ def _attributes_have_changed(
 
     if (
         adapt_brightness
-        and ATTR_BRIGHTNESS in old_attributes
-        and ATTR_BRIGHTNESS in new_attributes
+        and old_attributes.get(ATTR_BRIGHTNESS)
+        and new_attributes.get(ATTR_BRIGHTNESS)
     ):
         last_brightness = old_attributes[ATTR_BRIGHTNESS]
         current_brightness = new_attributes[ATTR_BRIGHTNESS]
@@ -736,8 +740,8 @@ def _attributes_have_changed(
 
     if (
         adapt_color
-        and ATTR_COLOR_TEMP_KELVIN in old_attributes
-        and ATTR_COLOR_TEMP_KELVIN in new_attributes
+        and old_attributes.get(ATTR_COLOR_TEMP_KELVIN)
+        and new_attributes.get(ATTR_COLOR_TEMP_KELVIN)
     ):
         last_color_temp = old_attributes[ATTR_COLOR_TEMP_KELVIN]
         current_color_temp = new_attributes[ATTR_COLOR_TEMP_KELVIN]
@@ -754,8 +758,8 @@ def _attributes_have_changed(
 
     if (
         adapt_color
-        and ATTR_RGB_COLOR in old_attributes
-        and ATTR_RGB_COLOR in new_attributes
+        and old_attributes.get(ATTR_RGB_COLOR)
+        and new_attributes.get(ATTR_RGB_COLOR)
     ):
         last_rgb_color = old_attributes[ATTR_RGB_COLOR]
         current_rgb_color = new_attributes[ATTR_RGB_COLOR]

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -713,7 +713,7 @@ def _attributes_have_changed(
     # 2023-11-19: HA core no longer removes light domain attributes when off
     # so we must protect for `None` here
     # see https://github.com/home-assistant/core/pull/101946
-    
+
     if adapt_color:
         old_attributes, new_attributes = _add_missing_attributes(
             old_attributes,


### PR DESCRIPTION
Addresses [change to HA core ](https://github.com/home-assistant/core/pull/101946) flagged in #832 which results in the following error:

```
Traceback (most recent call last):
  File "/config/custom_components/adaptive_lighting/switch.py", line 1129, in _async_update_at_interval_action
    await self._update_attrs_and_maybe_adapt_lights(
  File "/config/custom_components/adaptive_lighting/switch.py", line 1442, in _update_attrs_and_maybe_adapt_lights
    and await self.manager.significant_change(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/adaptive_lighting/switch.py", line 2461, in significant_change
    changed = _attributes_have_changed(
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/adaptive_lighting/switch.py", line 726, in _attributes_have_changed
    if abs(current_brightness - last_brightness) > BRIGHTNESS_CHANGE:
           ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```