### PR TITLE
README.md - Add note to access frontend UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The `adaptive_lighting.manual_control` event is fired when a light is marked as 
 
 ## :gear: Configuration
 
-Adaptive Lighting supports configuration through both YAML and the frontend (**Configuration** -> **Integrations** -> **Adaptive Lighting**, **Adaptive Lighting** -> **Options**), with identical option names in both methods.
+Adaptive Lighting supports configuration through both YAML and the frontend (**Settings** -> **Devices and Services** -> **Adaptive Lighting**, **Adaptive Lighting** -> **Options**), with identical option names in both methods.
 
 ```yaml
 # Example configuration.yaml entry
@@ -87,6 +87,7 @@ adaptive_lighting:
   lights:
     - light.living_room_lights
 ```
+Note: If you plan to strictly use the UI, the `adaptive_lighting:` entry must still be added to the YAML.
 
 Transform your home's atmosphere with Adaptive Lighting 🏠, and experience the benefits of intelligent, sun-synchronized lighting today!
 


### PR DESCRIPTION
I'm creating this PR simply because I wasn't sure if the `adaptive_lighting:` entry is a requirement to access the UI. The old `Configuration -> Integrations` now named `Settings -> Devices & Services` confused me. 

After reading this below, I'm unclear if it's possible to add configuration entries in the YAML and others via the UI. I'm used to see integrations either use either YAML or UI but never both at the same time. Per the wordings, it seems like it's possible to use both at the same time but likely making sure there's no collision, i.e. 2 identical names.

```
Configure an Adaptive Lighting component. Option names align with the YAML settings. If you've defined this entry in YAML, no options will appear here. For interactive graphs that demonstrate parameter effects, visit [this web app](https://basnijholt.github.io/adaptive-lighting). For further details, see the [official documentation](https://github.com/basnijholt/adaptive-lighting#readme).
```

Per any comments, the wording will probably need some adjustments but feel free to close this PR and make the proposed changes via another one.