### PR TITLE
Test that switch is on before updating time listeners

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -359,7 +359,8 @@ async def handle_change_switch_settings(
 
     # deep copy the defaults so we don't modify the original dicts
     switch._set_changeable_settings(data=data, defaults=deepcopy(defaults))
-    switch._update_time_interval_listener()
+    if switch.is_on:
+        switch._update_time_interval_listener()
 
     _LOGGER.debug(
         "Called 'adaptive_lighting.change_switch_settings' service with '%s'",


### PR DESCRIPTION
Calling `adaptive_lighting.change_switch_settings` while the lights are off will cause the below errors to appear in your HA logs:

```
2024-02-21 11:04:29.042 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/config/custom_components/adaptive_lighting/switch.py", line 1132, in _async_update_at_interval_action
    await self._update_attrs_and_maybe_adapt_lights(
  File "/config/custom_components/adaptive_lighting/switch.py", line 1361, in _update_attrs_and_maybe_adapt_lights
    assert self.is_on
AssertionError
```

These errors appear about every 90 seconds, I assume more or less depending on the set transition time. 

It appears this is because the function `handle_change_switch_settings` will always make a call to `_update_time_interval_listener`, even when the switch is off.  

This PR just adds a single line to check if the switch is on before calling the above function. 