### PR TITLE
Fix isinstance-asserts in switch.py

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1415,8 +1415,8 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
 
         adapt_brightness = self.adapt_brightness_switch.is_on
         adapt_color = self.adapt_color_switch.is_on
-        assert isinstance(adapt_brightness, bool)
-        assert isinstance(adapt_color, bool)
+        assert isinstance(adapt_brightness, bool | None)
+        assert isinstance(adapt_color, bool | None)
         tasks = []
         for light in filtered_lights:
             manually_controlled = (


### PR DESCRIPTION
This fixes the error reported in #919 

The `isinstance()` asserts need to match the corresponding typing definitions:
![image](https://github.com/basnijholt/adaptive-lighting/assets/11290930/46114d97-d390-4522-94ff-0a28733804c8)

Or, match to the corresponding `is_on` typing definition:
![image](https://github.com/basnijholt/adaptive-lighting/assets/11290930/676bd81a-bffe-4844-80d9-2fd7ef71b3be)
