### PR TITLE
Fix: noon and midnight adjustment

### DIFF
--- a/custom_components/adaptive_lighting/color_and_brightness.py
+++ b/custom_components/adaptive_lighting/color_and_brightness.py
@@ -111,8 +111,8 @@ class SunEvents:
         solar_noon = self.astral_location.noon(dt, local=False)
         solar_midnight = self.astral_location.midnight(dt, local=False)
 
-        solar_sunrise= self.astral_location.sunrise(dt, local=False)
-        solar_sunset= self.astral_location.sunset(dt, local=False)
+        solar_sunrise = self.astral_location.sunrise(dt, local=False)
+        solar_sunset = self.astral_location.sunset(dt, local=False)
 
         sunrise_offset = solar_sunrise - sunrise
         sunset_offset = solar_sunset - sunset

--- a/custom_components/adaptive_lighting/color_and_brightness.py
+++ b/custom_components/adaptive_lighting/color_and_brightness.py
@@ -105,30 +105,21 @@ class SunEvents:
         sunrise: datetime.datetime | None = None,
     ) -> tuple[datetime.datetime, datetime.datetime]:
         """Return the (adjusted) noon and midnight times for the given datetime."""
-        if (
-            self.sunrise_time is None
-            and self.sunset_time is None
-            and self.min_sunrise_time is None
-            and self.max_sunrise_time is None
-            and self.min_sunset_time is None
-            and self.max_sunset_time is None
-        ):
-            solar_noon = self.astral_location.noon(dt, local=False)
-            solar_midnight = self.astral_location.midnight(dt, local=False)
-            return solar_noon, solar_midnight
+        sunrise = sunrise or self.sunrise(dt)
+        sunset = sunset or self.sunset(dt)
 
-        if sunset is None:
-            sunset = self.sunset(dt)
-        if sunrise is None:
-            sunrise = self.sunrise(dt)
+        solar_noon = self.astral_location.noon(dt, local=False)
+        solar_midnight = self.astral_location.midnight(dt, local=False)
 
-        middle = abs(sunset - sunrise) / 2
-        if sunset > sunrise:
-            noon = sunrise + middle
-            midnight = noon + timedelta(hours=12) * (1 if noon.hour < 12 else -1)
-        else:
-            midnight = sunset + middle
-            noon = midnight + timedelta(hours=12) * (1 if midnight.hour < 12 else -1)
+        solar_sunrise= self.astral_location.sunrise(dt, local=False)
+        solar_sunset= self.astral_location.sunset(dt, local=False)
+
+        sunrise_offset = solar_sunrise - sunrise
+        sunset_offset = solar_sunset - sunset
+
+        noon = solar_noon - sunrise_offset
+        midnight = solar_midnight - sunset_offset
+
         return noon, midnight
 
     def sun_events(self, dt: datetime.datetime) -> list[tuple[str, float]]:

--- a/custom_components/adaptive_lighting/color_and_brightness.py
+++ b/custom_components/adaptive_lighting/color_and_brightness.py
@@ -105,30 +105,6 @@ class SunEvents:
         sunrise: datetime.datetime | None = None,
     ) -> tuple[datetime.datetime, datetime.datetime]:
         """Return the (adjusted) noon and midnight times for the given datetime."""
-        # if (
-        #     self.sunrise_time is None
-        #     and self.sunset_time is None
-        #     and self.min_sunrise_time is None
-        #     and self.max_sunrise_time is None
-        #     and self.min_sunset_time is None
-        #     and self.max_sunset_time is None
-        # ):
-        #     solar_noon = self.astral_location.noon(dt, local=False)
-        #     solar_midnight = self.astral_location.midnight(dt, local=False)
-        #     return solar_noon, solar_midnight
-
-        # if sunset is None:
-        #     sunset = self.sunset(dt)
-        # if sunrise is None:
-        #     sunrise = self.sunrise(dt)
-
-        # middle = abs(sunset - sunrise) / 2
-        # if sunset > sunrise:
-        #     noon = sunrise + middle
-        #     midnight = noon + timedelta(hours=12) * (1 if noon.hour < 12 else -1)
-        # else:
-        #     midnight = sunset + middle
-        #     noon = midnight + timedelta(hours=12) * (1 if midnight.hour < 12 else -1)
         sunrise = sunrise or self.sunrise(dt)
         sunset = sunset or self.sunset(dt)
 

--- a/custom_components/adaptive_lighting/color_and_brightness.py
+++ b/custom_components/adaptive_lighting/color_and_brightness.py
@@ -105,6 +105,30 @@ class SunEvents:
         sunrise: datetime.datetime | None = None,
     ) -> tuple[datetime.datetime, datetime.datetime]:
         """Return the (adjusted) noon and midnight times for the given datetime."""
+        # if (
+        #     self.sunrise_time is None
+        #     and self.sunset_time is None
+        #     and self.min_sunrise_time is None
+        #     and self.max_sunrise_time is None
+        #     and self.min_sunset_time is None
+        #     and self.max_sunset_time is None
+        # ):
+        #     solar_noon = self.astral_location.noon(dt, local=False)
+        #     solar_midnight = self.astral_location.midnight(dt, local=False)
+        #     return solar_noon, solar_midnight
+
+        # if sunset is None:
+        #     sunset = self.sunset(dt)
+        # if sunrise is None:
+        #     sunrise = self.sunrise(dt)
+
+        # middle = abs(sunset - sunrise) / 2
+        # if sunset > sunrise:
+        #     noon = sunrise + middle
+        #     midnight = noon + timedelta(hours=12) * (1 if noon.hour < 12 else -1)
+        # else:
+        #     midnight = sunset + middle
+        #     noon = midnight + timedelta(hours=12) * (1 if midnight.hour < 12 else -1)
         sunrise = sunrise or self.sunrise(dt)
         sunset = sunset or self.sunset(dt)
 

--- a/scripts/setup-dependencies
+++ b/scripts/setup-dependencies
@@ -2,7 +2,7 @@
 set -ex
 cd "$(dirname "$0")/.."
 
-pip install -r core/requirements.txt --root-user-action
+pip install -r core/requirements.txt --root-user-action=ignore
 
 if grep -q 'codecov' core/requirements_test.txt; then
     # Older HA versions still have `codecov` in `requirements_test.txt`
@@ -14,8 +14,8 @@ if grep -q 'mypy-dev==1.10.0a3' core/requirements_test.txt; then
     # mypy-dev==1.10.0a3 seems to not be available anymore, HA 2024.4 and 2024.5 are affected
     sed -i 's/mypy-dev==1.10.0a3/mypy-dev==1.10.0b1/' core/requirements_test.txt
 fi
-pip install -r core/requirements_test.txt --root-user-action
+pip install -r core/requirements_test.txt --root-user-action=ignore
 
-pip install -e core/ --root-user-action
+pip install -e core/ --root-user-action=ignore
 pip install ulid-transform # this is in Adaptive-lighting's manifest.json
-pip install $(python test_dependencies.py) --root-user-action
+pip install $(python test_dependencies.py) --root-user-action=ignore

--- a/scripts/setup-dependencies
+++ b/scripts/setup-dependencies
@@ -2,7 +2,7 @@
 set -ex
 cd "$(dirname "$0")/.."
 
-pip install -r core/requirements.txt
+pip install -r core/requirements.txt --root-user-action
 
 if grep -q 'codecov' core/requirements_test.txt; then
     # Older HA versions still have `codecov` in `requirements_test.txt`
@@ -14,8 +14,8 @@ if grep -q 'mypy-dev==1.10.0a3' core/requirements_test.txt; then
     # mypy-dev==1.10.0a3 seems to not be available anymore, HA 2024.4 and 2024.5 are affected
     sed -i 's/mypy-dev==1.10.0a3/mypy-dev==1.10.0b1/' core/requirements_test.txt
 fi
-pip install -r core/requirements_test.txt
+pip install -r core/requirements_test.txt --root-user-action
 
-pip install -e core/
+pip install -e core/ --root-user-action
 pip install ulid-transform # this is in Adaptive-lighting's manifest.json
-pip install $(python test_dependencies.py)
+pip install $(python test_dependencies.py) --root-user-action

--- a/scripts/setup-symlinks
+++ b/scripts/setup-symlinks
@@ -1,13 +1,8 @@
 #!/usr/bin/env bash
 set -ex
-cd "$(dirname "$0")/.."
 
 # Link custom components
-cd core/homeassistant/components/
-ln -fs ../../../custom_components/adaptive_lighting adaptive_lighting
-cd -
+ln -fs /app/custom_components/adaptive_lighting /core/homeassistant/components/adaptive_lighting
 
 # Link tests
-cd core/tests/components/
-ln -fs ../../../tests/ adaptive_lighting
-cd -
+ln -fs /app/tests /core/tests/components/adaptive_lighting

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1347,7 +1347,6 @@ def mock_area_registry(
     registry._area_data = {}
     area_kwargs = {
         "name": "Test Area",
-        "normalized_name": "test-area",
         "id": "test-area",
         "picture": None,
     }


### PR DESCRIPTION
Might resolve #902 and other issues related to incorrectly adjusting noon and midnight times.

I live in London and today is the day where solar midnight is very close to actual midnight. It's around 23:59. What happened this evening is that my lights suddenly went from their normal percentage to 1%. (It wasn't sleep mode.) My guess (and @Viproz's in #902) is also that the custom midnight calculation in `noon_and_midnight` is incorrect. When the custom logic is triggered by for example setting `min_sunset_time`, `prev_and_next_events` returned the event types sunset, sunrise when it should have returned sunset, solar_midnight.

I debugged and it's clear that when this occurs, the custom code does not fix the day properly:

Inside of `SunEvents.prev_and_next_events` it calculates yesterday's, today's, and tomorrow's events. If we log those, we get this when having not changed any values that would trigger the custom logic:

```
0. event_name='solar_midnight'
0. event_time_formatted=datetime.datetime(2024, 4, 16, 23, 59, 42)
1. event_name='sunrise'
1. event_time_formatted=datetime.datetime(2024, 4, 17, 4, 59, 32, 723716)
2. event_name='solar_noon'
2. event_time_formatted=datetime.datetime(2024, 4, 17, 11, 59, 48)
3. event_name='sunset'
3. event_time_formatted=datetime.datetime(2024, 4, 17, 19, 0, 56, 58566)
4. event_name='solar_midnight'
4. event_time_formatted=datetime.datetime(2024, 4, 17, 23, 59, 29)
5. event_name='sunrise'
5. event_time_formatted=datetime.datetime(2024, 4, 18, 4, 57, 25, 655122)
6. event_name='solar_noon'
6. event_time_formatted=datetime.datetime(2024, 4, 18, 11, 59, 35)
7. event_name='sunset'
7. event_time_formatted=datetime.datetime(2024, 4, 18, 19, 2, 36, 688279)
8. event_name='solar_midnight'
8. event_time_formatted=datetime.datetime(2024, 4, 18, 23, 59, 16)
9. event_name='sunrise'
9. event_time_formatted=datetime.datetime(2024, 4, 19, 4, 55, 19, 432385)
10. event_name='solar_noon'
10. event_time_formatted=datetime.datetime(2024, 4, 19, 11, 59, 21)
11. event_name='sunset'
11. event_time_formatted=datetime.datetime(2024, 4, 19, 19, 4, 17, 265827)
```

You can see that it always follows the same pattern cyclically: `solar_midnight`, `sunrise`, `solar_noon`, `sunset`, and so on. When changing for example `min_sunset_time` and `max_sunset_time` even though they don't affect the eventually calculated sunset time, it will give the following incorrect result:

```
0. event_name='solar_midnight'
0. event_time_formatted=datetime.datetime(2024, 4, 17, 0, 0, 14, 391141)
1. event_name='sunrise'
1. event_time_formatted=datetime.datetime(2024, 4, 17, 4, 59, 32, 723716)
2. event_name='solar_noon'
2. event_time_formatted=datetime.datetime(2024, 4, 17, 12, 0, 14, 391141)
3. event_name='sunset'
3. event_time_formatted=datetime.datetime(2024, 4, 17, 19, 0, 56, 58566)
4. event_name='solar_midnight'
4. event_time_formatted=datetime.datetime(2024, 4, 18, 0, 0, 1, 171700)
5. event_name='sunrise'
5. event_time_formatted=datetime.datetime(2024, 4, 18, 4, 57, 25, 655122)
6. event_name='solar_noon'
6. event_time_formatted=datetime.datetime(2024, 4, 18, 12, 0, 1, 171700)
7. event_name='sunset'
7. event_time_formatted=datetime.datetime(2024, 4, 18, 19, 2, 36, 688279)
8. event_name='sunrise'
8. event_time_formatted=datetime.datetime(2024, 4, 19, 4, 55, 19, 432385)
9. event_name='solar_noon'
9. event_time_formatted=datetime.datetime(2024, 4, 19, 11, 59, 48, 349106)
10. event_name='sunset'
10. event_time_formatted=datetime.datetime(2024, 4, 19, 19, 4, 17, 265827)
11. event_name='solar_midnight'
11. event_time_formatted=datetime.datetime(2024, 4, 19, 23, 59, 48, 349106)
```

You can see that it incorrectly added a day to the last solar midnight leading to `sunset` -> `sunrise` instead of `sunset` -> `solar_midnight` -> `sunrise`.

I've fixed it so we do not need to any special calculations to figure out whether to add/remove a day. I am calculating the offset between the "adjusted offset" and "real sunset" and apply the same delta to midnight. (The same for sunrise and noon.) This leads to the above example returning the correct first example.

When we change the `sunset_max_time` to something like 4PM, we can also see that the difference is applied correctly:

```
0. event_name='solar_midnight'
0. event_time_formatted=datetime.datetime(2024, 4, 16, 20, 58, 45, 941434)
1. event_name='sunrise'
1. event_time_formatted=datetime.datetime(2024, 4, 17, 4, 59, 32, 723716)
2. event_name='solar_noon'
2. event_time_formatted=datetime.datetime(2024, 4, 17, 11, 59, 48)
3. event_name='sunset'
3. event_time_formatted=datetime.datetime(2024, 4, 17, 16, 0)
4. event_name='solar_midnight'
4. event_time_formatted=datetime.datetime(2024, 4, 17, 20, 56, 52, 311721)
5. event_name='sunrise'
5. event_time_formatted=datetime.datetime(2024, 4, 18, 4, 57, 25, 655122)
6. event_name='solar_noon'
6. event_time_formatted=datetime.datetime(2024, 4, 18, 11, 59, 35)
7. event_name='sunset'
7. event_time_formatted=datetime.datetime(2024, 4, 18, 16, 0)
8. event_name='solar_midnight'
8. event_time_formatted=datetime.datetime(2024, 4, 18, 20, 54, 58, 734173)
9. event_name='sunrise'
9. event_time_formatted=datetime.datetime(2024, 4, 19, 4, 55, 19, 432385)
10. event_name='solar_noon'
10. event_time_formatted=datetime.datetime(2024, 4, 19, 11, 59, 21)
11. event_name='sunset'
11. event_time_formatted=datetime.datetime(2024, 4, 19, 16, 0)
```

I primarily tested this with sunset and midnight, though it should work the same for sunrise and noon.