### PR TITLE
Remove deprecated 'run_immediately'

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -60,7 +60,6 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.const import __version__ as ha_version
 from homeassistant.core import (
     CALLBACK_TYPE,
     Context,
@@ -950,15 +949,9 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         if self.hass.is_running:
             await self._setup_listeners()
         else:
-            kw = {}
-            year, month = (int(x) for x in ha_version.split(".")[:2])
-            if (year, month) >= (2024, 4):
-                # Added in https://github.com/home-assistant/core/pull/113020
-                kw["run_immediately"] = False
             self.hass.bus.async_listen_once(
                 EVENT_HOMEASSISTANT_STARTED,
                 self._setup_listeners,
-                **kw,
             )
         last_state: State | None = await self.async_get_last_state()
         is_new_entry = last_state is None  # newly added to HA
@@ -1665,12 +1658,10 @@ class AdaptiveLightingManager:
             self.hass.bus.async_listen(
                 EVENT_CALL_SERVICE,
                 self.turn_on_off_event_listener,
-                run_immediately=False,
             ),
             self.hass.bus.async_listen(
                 EVENT_STATE_CHANGED,
                 self.state_changed_event_listener,
-                run_immediately=False,
             ),
         ]
 


### PR DESCRIPTION
Remove 'run_immediately' which will be deprecated in version 2025.5

I removed 'run immediately' from the 'async_listen' and 'async_listen_once' calls since this argument will be deprecated in versions > 2025.5 as indicated in the debug LOG

```
Detected that custom integration 'adaptive_lighting' calls `async_listen` with run_immediately, which is deprecated and will be removed in Home Assistant 2025.5 at custom_components/adaptive_lighting/switch.py, line 1665: self.hass.bus.async_listen(, please create a bug report at https://github.com/basnijholt/adaptive-lighting/issues
Detected that custom integration 'adaptive_lighting' calls `async_listen` with run_immediately, which is deprecated and will be removed in Home Assistant 2025.5 at custom_components/adaptive_lighting/switch.py, line 1670: self.hass.bus.async_listen(, please create a bug report at https://github.com/basnijholt/adaptive-lighting/issues
Detected that custom integration 'adaptive_lighting' calls `async_listen_once` with run_immediately, which is deprecated and will be removed in Home Assistant 2025.5 at custom_components/adaptive_lighting/switch.py, line 958: self.hass.bus.async_listen_once(, please create a bug report at https://github.com/basnijholt/adaptive-lighting/issues
```
As well as on this pull request from HomeAssistant Core : https://github.com/home-assistant/core/pull/115169

This resolves the issue https://github.com/basnijholt/adaptive-lighting/issues/984

I hope I don't do anything stupid, I just want to make my little contribution 
Thank you for the work you put in for this custom_component!