### PR TITLE
fix: Detected code that calls async_forward_entry_setup

### DIFF
--- a/custom_components/adaptive_lighting/__init__.py
+++ b/custom_components/adaptive_lighting/__init__.py
@@ -65,10 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
     undo_listener = config_entry.add_update_listener(async_update_options)
     data[config_entry.entry_id] = {UNDO_UPDATE_LISTENER: undo_listener}
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(config_entry, platform),
-        )
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True
 

--- a/custom_components/adaptive_lighting/strings.json
+++ b/custom_components/adaptive_lighting/strings.json
@@ -49,7 +49,7 @@
           "detect_non_ha_changes": "detect_non_ha_changes: Detects and halts adaptations for non-`light.turn_on` state changes. Needs `take_over_control` enabled. 🕵️ Caution: ⚠️ Some lights might falsely indicate an 'on' state, which could result in lights turning on unexpectedly. Disable this feature if you encounter such issues.",
           "autoreset_control_seconds": "autoreset_control_seconds",
           "only_once": "only_once: Adapt lights only when they are turned on (`true`) or keep adapting them (`false`). 🔄",
-          "adapt_only_on_bare_turn_on": "adapt_only_on_bare_turn_on: When turning lights on initially. If set to `true`, AL adapts only if `light.turn_on` is invoked without specifying color or brightness. ❌🌈 This e.g., prevents adaptation when activating a scene. If `false`, AL adapts regardless of the presence of color or brightness in the initial `service_data`. Needs `take_over_control` enabled. 🕵️ ",
+          "adapt_only_on_bare_turn_on": "adapt_only_on_bare_turn_on: When turning lights on initially. If set to `true`, AL adapts only if `light.turn_on` is invoked without specifying color or brightness. ❌🌈 This e.g., prevents adaptation when activating a scene. If `false`, AL adapts regardless of the presence of color or brightness in the initial `service_data`. Needs `take_over_control` enabled. 🕵️",
           "separate_turn_on_commands": "separate_turn_on_commands: Use separate `light.turn_on` calls for color and brightness, needed for some light types. 🔀",
           "send_split_delay": "send_split_delay",
           "adapt_delay": "adapt_delay",


### PR DESCRIPTION
Change `async_setup_entry` to use `await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)`

Fixes https://github.com/basnijholt/adaptive-lighting/issues/1020
