### PR TITLE
Remove trailing space from string in const.py

### DIFF
--- a/custom_components/adaptive_lighting/const.py
+++ b/custom_components/adaptive_lighting/const.py
@@ -28,7 +28,7 @@ CONF_DETECT_NON_HA_CHANGES, DEFAULT_DETECT_NON_HA_CHANGES = (
 )
 DOCS[CONF_DETECT_NON_HA_CHANGES] = (
     "Detects and halts adaptations for non-`light.turn_on` state changes. "
-    "Needs `take_over_control` enabled. 🕵️ "
+    "Needs `take_over_control` enabled. 🕵️"
     "Caution: ⚠️ Some lights might falsely indicate an 'on' state, which could result "
     "in lights turning on unexpectedly. "
     "Disable this feature if you encounter such issues."


### PR DESCRIPTION
The [Validate with hassfest](https://github.com/basnijholt/adaptive-lighting/actions/workflows/hassfest.yaml) workflow is constantly failing since [Sep 26th](https://github.com/basnijholt/adaptive-lighting/actions/runs/11042957978) with the following error message:
```
[TRANSLATIONS] Invalid translations/en.json: the string should not contain leading or trailing spaces for dictionary value @ data['options']['step']['init']['data']['adapt_only_on_bare_turn_on']. Got 'adapt_only_on_bare_turn_on: When turning lights on initially. If set to `true`, AL adapts only if `light.turn_on` is invoked without specifying color or brightness. ❌🌈 This e.g., prevents adaptation when activating a scene. If `false`, AL adapts regardless of the presence of color or brightness in the initial `service_data`. Needs `take_over_control` enabled. 🕵️ '
```
The error message is the same ever since for every other failed workflow run.

My small change aims to fix the issue, hopefully making the workflow succeed.