### PR TITLE
Fix setting config_entry directly in ≥2024.12

### DIFF
--- a/custom_components/adaptive_lighting/config_flow.py
+++ b/custom_components/adaptive_lighting/config_flow.py
@@ -84,9 +84,13 @@ def validate_options(user_input, errors):
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a option flow for Adaptive Lighting."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
+        if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 12):
+            super().__init__(*args, **kwargs)
+            # https://github.com/home-assistant/core/pull/129651
+        else:
+            self.config_entry = args[0]
 
     async def async_step_init(self, user_input=None):
         """Handle options flow."""

--- a/custom_components/adaptive_lighting/config_flow.py
+++ b/custom_components/adaptive_lighting/config_flow.py
@@ -5,7 +5,7 @@ import logging
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, MAJOR_VERSION, MINOR_VERSION
 from homeassistant.core import callback
 
 from .const import (  # pylint: disable=unused-import
@@ -58,6 +58,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
+        if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 12):
+            # https://github.com/home-assistant/core/pull/129651
+            return OptionsFlowHandler()
         return OptionsFlowHandler(config_entry)
 
 


### PR DESCRIPTION
Fixes
`FAILED tests/components/adaptive_lighting/test_config_flow.py::test_incorrect_options - RuntimeError: Detected that integration 'adaptive_lighting' sets option flow config_entry explicitly, which is deprecated at homeassistant/components/adaptive_lighting/config_flow.py, line 86: self.config_entry = config_entry. Please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+adaptive_lighting%22`