### PR TITLE
Improve Color Calculation and Adjust To Sleep Transition

### DIFF
--- a/custom_components/adaptive_lighting/color_and_brightness.py
+++ b/custom_components/adaptive_lighting/color_and_brightness.py
@@ -311,12 +311,16 @@ class SunLightSettings:
 
     def color_temp_mired(self, sun_position: float) -> int:
         """Calculate the color temperature in Mired."""
-        min_mired = math.floor(1000000 / self.max_color_temp) # mired is reciprocal to kelvin: min<->max
+        min_mired = math.floor(
+            1000000 / self.max_color_temp
+        )  # mired is reciprocal to kelvin: min<->max
         max_mired = math.floor(1000000 / self.min_color_temp)
         sleep_mired = math.floor(1000000 / self.sleep_color_temp)
         if sun_position > 0:
             delta = max_mired - min_mired
-            ct = (delta * (1 - sun_position)) + min_mired # the higher the sun, the lower the mired & vv
+            ct = (
+                delta * (1 - sun_position)
+            ) + min_mired  # the higher the sun, the lower the mired & vv
             return round(ct)
         if sun_position == 0 or not self.adapt_until_sleep:
             return max_mired

--- a/webapp/color_and_brightness.py
+++ b/webapp/color_and_brightness.py
@@ -311,12 +311,16 @@ class SunLightSettings:
 
     def color_temp_mired(self, sun_position: float) -> int:
         """Calculate the color temperature in Mired."""
-        min_mired = math.floor(1000000 / self.max_color_temp) # mired is reciprocal to kelvin: min<->max
+        min_mired = math.floor(
+            1000000 / self.max_color_temp
+        )  # mired is reciprocal to kelvin: min<->max
         max_mired = math.floor(1000000 / self.min_color_temp)
         sleep_mired = math.floor(1000000 / self.sleep_color_temp)
         if sun_position > 0:
             delta = max_mired - min_mired
-            ct = (delta * (1 - sun_position)) + min_mired # the higher the sun, the lower the mired & vv
+            ct = (
+                delta * (1 - sun_position)
+            ) + min_mired  # the higher the sun, the lower the mired & vv
             return round(ct)
         if sun_position == 0 or not self.adapt_until_sleep:
             return max_mired


### PR DESCRIPTION
Based on the following info, I have implemented a color calculation strategy based on the mired scale that should result in a more natural progression of the color change over the course of the day.
<img width="491" height="278" alt="source" src="https://github.com/user-attachments/assets/ae176214-2471-44b9-b388-ac8227ff9129" />
Source: https://en.wikipedia.org/wiki/Mired

The results can be seen here (using 10000K as max temp, as the latest Hue bulbs support up to 20000K):

Before:
<img width="1374" height="411" alt="before" src="https://github.com/user-attachments/assets/7319dbee-0b61-4044-ad9b-a06a1e69a357" />

After:
<img width="1373" height="402" alt="new" src="https://github.com/user-attachments/assets/9cf7ad6a-59f2-4b31-af76-66922c0ccd88" />

By using the following settings:
<img width="256" height="1196" alt="settings" src="https://github.com/user-attachments/assets/9d8fd584-052a-4a56-b0a1-d8102835b772" />

Note that I also changed (fixed?) the transition to sleep (using moonlight color, 4120K, for demonstration).