### PR TITLE
Fix xfail and skipped tests to properly pass

### DIFF
--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1296,13 +1296,17 @@ async def test_restore_off_state(hass, state):
                     assert not _switch.is_on
 
 
-@pytest.mark.xfail(reason="Offset is larger than half a day")
 async def test_offset_too_large(hass):
-    """Test that update fails when the offset is too large."""
+    """Test that update fails when the sunrise offset is too large.
+
+    A 12-hour offset causes sun events to be out of order (e.g., sunrise after sunset),
+    which makes the adaptive lighting algorithm fail with a ValueError.
+    """
     _, switch = await setup_switch(hass, {CONF_SUNRISE_OFFSET: 3600 * 12})
-    await switch._update_attrs_and_maybe_adapt_lights(
-        context=switch.create_context("test"),
-    )
+    with pytest.raises(ValueError, match="sun events.*not in the expected order"):
+        await switch._update_attrs_and_maybe_adapt_lights(
+            context=switch.create_context("test"),
+        )
     await hass.async_block_till_done()
 
 


### PR DESCRIPTION
## Summary

- Fix `test_offset_too_large` (was xfail) - properly assert that `ValueError` is raised when sunrise offset is too large
- Fix `test_options_flow_for_yaml_import` (was skipped) - populate `__yaml__` set required for YAML-imported entries

## Details

### `test_offset_too_large`

The test was marked as `@pytest.mark.xfail` with no assertions. A 12-hour sunrise offset causes sun events to be out of order (e.g., sunrise after sunset), which triggers a `ValueError` in `_validate_sun_event_order()`. This is intentional validation - the fix properly asserts the expected exception.

### `test_options_flow_for_yaml_import` (renamed from `test_changing_options_when_using_yaml`)

The test was skipped with "TODO: Fix, broken for all supported versions". The root cause was that `switch.py:402-411` checks if `unique_id in hass.data[DOMAIN]["__yaml__"]` for YAML imports - if not found, it deletes the entry, causing timeouts.

The fix populates `__yaml__` (simulating what `async_step_import` does) and adds assertions verifying that YAML imports show an empty options form (`data_schema=None`).

## Test plan

- [x] `test_offset_too_large` passes
- [x] `test_options_flow_for_yaml_import` passes  
- [x] All 133 tests pass (previously 131 passed + 1 skipped + 1 xfailed)