### PR TITLE
Stop pinning mypy-dev versions since old releases get deleted from PyPI

### DIFF
--- a/scripts/setup-dependencies
+++ b/scripts/setup-dependencies
@@ -2,29 +2,16 @@
 set -ex
 cd "$(dirname "$0")/.."
 
-if grep -q 'mypy-dev==1.14.0a3' core/requirements_test.txt; then
-    # mypy-dev==1.14.0a3 seems to not be available anymore, HA 2024.12 is affected
-    sed -i 's/mypy-dev==1.14.0a3/mypy-dev==1.14.0a7/' core/requirements_test.txt
-fi
-if grep -q 'mypy-dev==1.16.0a1' core/requirements_test.txt; then
-    # mypy-dev==1.16.0a1 seems to not be available anymore, HA 2025.2 is affected
-    sed -i 's/mypy-dev==1.16.0a1/mypy-dev==1.16.0a9/' core/requirements_test.txt
-fi
-if grep -q 'mypy-dev==1.16.0a3' core/requirements_test.txt; then
-    # mypy-dev==1.16.0a3 seems to not be available anymore, HA 2025.3 is affected
-    sed -i 's/mypy-dev==1.16.0a3/mypy-dev==1.16.0a9/' core/requirements_test.txt
-fi
-if grep -q 'mypy-dev==1.16.0a7' core/requirements_test.txt; then
-    # mypy-dev==1.16.0a7 seems to not be available anymore, HA 2025.4 is affected
-    sed -i 's/mypy-dev==1.16.0a7/mypy-dev==1.16.0a9/' core/requirements_test.txt
-fi
-if grep -q 'mypy-dev==1.16.0a8' core/requirements_test.txt; then
-    # mypy-dev==1.16.0a8 seems to not be available anymore, HA 2025.5 and 2025.6 is affected
-    sed -i 's/mypy-dev==1.16.0a8/mypy-dev==1.16.0a9/' core/requirements_test.txt
-fi
+# Remove mypy-dev from requirements_test.txt since the maintainer deletes old versions from PyPI.
+# We'll install the latest version separately below.
+# See: https://github.com/cdce8p/mypy-dev/issues/62
+sed -i '/^mypy-dev/d' core/requirements_test.txt
 
 uv pip install -r core/requirements.txt
 uv pip install -r core/requirements_test.txt
 uv pip install -e core/
 uv pip install ulid-transform # this is in Adaptive-lighting's manifest.json
 uv pip install $(python test_dependencies.py)
+
+# Install the latest mypy-dev (not pinned since old versions get deleted from PyPI)
+uv pip install --upgrade mypy-dev


### PR DESCRIPTION
## Summary

Simplify `scripts/setup-dependencies` by removing the growing list of sed commands that replace deleted mypy-dev versions. Instead, remove the mypy-dev line from `requirements_test.txt` and install the latest version separately.

## Problem

The mypy-dev maintainer [deletes old releases from PyPI](https://github.com/cdce8p/mypy-dev/issues/62) due to storage constraints. This required us to keep adding sed commands every time a version was deleted:

```bash
# Before: 5 different sed commands for deleted versions
if grep -q 'mypy-dev==1.14.0a3' ...; then sed ... fi
if grep -q 'mypy-dev==1.16.0a1' ...; then sed ... fi
if grep -q 'mypy-dev==1.16.0a3' ...; then sed ... fi
if grep -q 'mypy-dev==1.16.0a7' ...; then sed ... fi
if grep -q 'mypy-dev==1.16.0a8' ...; then sed ... fi
```

## Solution

Follow the maintainer's suggestion: don't pin specific versions, just install the latest:

```bash
# After: simple and future-proof
sed -i '/^mypy-dev/d' core/requirements_test.txt
# ... install other deps ...
uv pip install --upgrade mypy-dev
```

## Test plan

- [x] Tests still pass with the Docker image