### PR TITLE
fix(ci): add branch filter to TOC generator workflow

### DIFF
--- a/.github/workflows/toc.yaml
+++ b/.github/workflows/toc.yaml
@@ -1,4 +1,6 @@
-on: push
+on:
+  push:
+    branches: [main]
 name: TOC Generator
 jobs:
   generateTOC:


### PR DESCRIPTION
## Problem

Hi, amazing HA addition you've built for adaptive-lighting. I tried to run it locally for dev purposes and ran into a few sharp edges, as well as unobvious decisions in the setup.
I had Claude assist me in getting the repo set up for development purposes and fix the sharp edges. These PRs contain some patches that might be useful for you. Use or discard as you see fit. The usual ultra verbose Claude description below, take it with a grain of salt.

In this case:
- The TOC (Table of Contents) generator currently runs on **every push to any branch**:

```yaml
on: push
```

**Issues:**
- 🔄 Runs unnecessarily on feature branches
- 💰 Wastes GitHub Actions minutes
- 📝 Creates commits on branches that will be squashed anyway
- ⚠️ Potential merge conflicts if multiple branches update TOC

## Solution

Add a simple branch filter:

```yaml
on:
  push:
    branches: [main]
```

## Benefits

- ✅ **Reduces CI waste** - Only runs where TOC matters
- ✅ **Saves resources** - Fewer GitHub Actions minutes used
- ✅ **Cleaner history** - No TOC commits on feature branches
- ✅ **Aligns with other workflows** - Matches pytest, pre-commit patterns

## Comparison

**Other workflows in the repo:**
```yaml
# pytest.yaml
on:
  push:
    branches: [main]

# pre-commit.yaml  
on:
  push:
    branches: [main]

# validate.yml
on:
  push:
    branches: [main]
```

**TOC should match this pattern.**

## Impact

- ✅ No change to main branch behavior
- ✅ Feature branches won't trigger TOC updates
- ✅ TOC still updates on every main branch push
- ✅ No breaking changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)