### PR TITLE
Fix Docker volume mounts overwriting build-time symlinks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,29 +35,8 @@ WORKDIR /app/core
 # Make 'custom_components/adaptive_lighting' imports available to tests
 ENV PYTHONPATH="${PYTHONPATH}:/app"
 
-ENTRYPOINT ["python3", \
-    # Enable Python development mode
-    "-X", "dev", \
-    # Run pytest
-    "-m", "pytest", \
-    # Verbose output
-    "-vvv", \
-    # Set a timeout of 9 seconds per test
-    "--timeout=9", \
-    # Print the 10 slowest tests
-    "--durations=10", \
-    # Measure code coverage for the 'homeassistant' package
-    "--cov='homeassistant'", \
-    # Generate an XML report of the code coverage
-    "--cov-report=xml", \
-    # Generate an HTML report of the code coverage
-    "--cov-report=html", \
-    # Print a summary of the code coverage in the console
-    "--cov-report=term", \
-    # Print logs in color
-    "--color=yes", \
-    # Print a count of test results in the console
-    "-o", "console_output_style=count"]
+# Entrypoint sets up symlinks at runtime (needed because volume mount overwrites build-time symlinks)
+ENTRYPOINT ["/app/scripts/docker-entrypoint.sh"]
 
 # Run tests in the 'tests/components/adaptive_lighting' directory
 CMD ["tests/components/adaptive_lighting"]

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Entrypoint script for Docker container
+# Sets up symlinks at runtime (needed because volume mount overwrites build-time symlinks)
+
+set -e
+
+# Create symlinks with absolute paths so they work after volume mount
+ln -sfn /app/custom_components/adaptive_lighting /core/homeassistant/components/adaptive_lighting
+ln -sfn /app/tests /core/tests/components/adaptive_lighting
+
+# Run pytest with all arguments
+exec python3 -X dev -m pytest \
+    -vvv \
+    --timeout=9 \
+    --durations=10 \
+    --cov='homeassistant' \
+    --cov-report=xml \
+    --cov-report=html \
+    --cov-report=term \
+    --color=yes \
+    -o console_output_style=count \
+    "$@"


### PR DESCRIPTION
## Summary
- Move pytest command from Dockerfile ENTRYPOINT to a separate entrypoint script
- Entrypoint script recreates symlinks at runtime, after volume mounts are applied
- Allows mounting local code with `-v $(pwd)/custom_components:/app/custom_components` without breaking symlinks

## Problem
When using volume mounts to test local code changes:
```bash
docker run -v $(pwd)/custom_components/adaptive_lighting:/app/custom_components/adaptive_lighting ...
```
The mount overwrites the build-time symlinks, causing "module not found" errors.

## Solution
The entrypoint script runs `ln -sfn` to recreate symlinks after volumes are mounted, ensuring tests can find the component and test files.

## Test plan
- [ ] Build Docker image: `docker build -t adaptive-lighting-test .`
- [ ] Run tests with volume mount: `docker run -v $(pwd)/custom_components/adaptive_lighting:/app/custom_components/adaptive_lighting -v $(pwd)/tests:/app/tests adaptive-lighting-test`