### PR TITLE
Enable Plausible analytics

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -84,6 +84,9 @@ repo = "lucide/github"
 [project.extra]
 generator = false
 
+[project.extra.analytics]
+provider = "custom"
+
 [[project.extra.social]]
 icon = "fontawesome/brands/github"
 link = "https://github.com/basnijholt/adaptive-lighting"


### PR DESCRIPTION
## Summary
- Add `[project.extra.analytics]` config with `provider = "custom"` to enable the custom Plausible analytics partial

The custom.html template was already in place but wasn't being loaded because the analytics provider wasn't configured.