### PR TITLE
Fix light groups not adapting when child lights turned on

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -2830,9 +2830,8 @@ class AdaptiveLightingManager:
             transition = None
 
         # Check if the off→on state change was triggered by a light.turn_on call.
-        # This check now also handles light groups: if a member light was turned on
-        # after the group turned off, the group's turn-on is considered valid.
-        # See: https://github.com/basnijholt/adaptive-lighting/issues/1378
+        # For light groups, this also checks if a member's turn_on explains the
+        # group's turn-on (handles cases where context IDs don't match).
         if self._off_to_on_state_event_is_from_turn_on(entity_id, off_to_on_event):
             is_toggle = off_to_on_event == self.toggle_event.get(entity_id)
             from_service = "light.toggle" if is_toggle else "light.turn_on"

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -2781,21 +2781,6 @@ class AdaptiveLightingManager:
             )
             return False
 
-        # Check if the off→on state change was triggered by a light.turn_on call.
-        # This check now also handles light groups: if a member light was turned on
-        # after the group turned off, the group's turn-on is considered valid.
-        # See: https://github.com/basnijholt/adaptive-lighting/issues/1378
-        if self._off_to_on_state_event_is_from_turn_on(entity_id, off_to_on_event):
-            is_toggle = off_to_on_event == self.toggle_event.get(entity_id)
-            from_service = "light.toggle" if is_toggle else "light.turn_on"
-            _LOGGER.debug(
-                "just_turned_off: State change 'off' → 'on' triggered by '%s'",
-                from_service,
-            )
-            return False
-
-        # If context IDs match but no turn_on event was found, this is likely a polling
-        # artifact (HA briefly seeing the light as ON during a turn_off transition).
         if off_to_on_event.context.id == on_to_off_event.context.id:
             _LOGGER.debug(
                 "just_turned_off: 'on' → 'off' state change has the same context.id as the"
@@ -2811,6 +2796,19 @@ class AdaptiveLightingManager:
             transition = turn_off_event.data[ATTR_SERVICE_DATA].get(ATTR_TRANSITION)
         else:
             transition = None
+
+        # Check if the off→on state change was triggered by a light.turn_on call.
+        # This check now also handles light groups: if a member light was turned on
+        # after the group turned off, the group's turn-on is considered valid.
+        # See: https://github.com/basnijholt/adaptive-lighting/issues/1378
+        if self._off_to_on_state_event_is_from_turn_on(entity_id, off_to_on_event):
+            is_toggle = off_to_on_event == self.toggle_event.get(entity_id)
+            from_service = "light.toggle" if is_toggle else "light.turn_on"
+            _LOGGER.debug(
+                "just_turned_off: State change 'off' → 'on' triggered by '%s'",
+                from_service,
+            )
+            return False
 
         if (
             turn_off_event is not None

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -3142,3 +3142,117 @@ async def test_just_turned_off_polling_artifact_still_detected(hass):
         "just_turned_off should return True (block adaptation) when context IDs match "
         "and no turn_on event explains the off→on. This is a polling artifact."
     )
+
+
+async def test_just_turned_off_context_reuse_with_light_groups(hass):
+    """Test that light groups adapt even when HA reuses the turn_off context ID.
+
+    Regression test for https://github.com/basnijholt/adaptive-lighting/issues/1378
+
+    This is the CRITICAL test case that was missing. It tests the actual scenario:
+    1. A light group is turned off (stores on_to_off_event with context A)
+    2. A member light is turned on by automation (stores turn_on_event with context B)
+    3. The group turns back on as a side effect
+    4. Home Assistant reuses the turn_off context (off_to_on_event has context A!)
+    5. just_turned_off() is called - it should return False (allow adaptation)
+
+    The bug: The context ID match check at line 2804 returns True early,
+    blocking adaptation before the member turn_on check at line 2824 is reached.
+    """
+    from homeassistant.core import Context, Event
+
+    # Setup lights with a group (light_group contains light_4 and light_5)
+    lights = await setup_lights(hass, with_group=True)
+    entity_ids = [light.entity_id for light in lights[:3]]
+    entity_ids.append("light.light_group")
+
+    _, switch = await setup_switch(
+        hass,
+        {
+            CONF_LIGHTS: entity_ids,
+            CONF_SUNRISE_TIME: datetime.time(SUNRISE.hour),
+            CONF_SUNSET_TIME: datetime.time(SUNSET.hour),
+            CONF_INITIAL_TRANSITION: 0,
+            CONF_TRANSITION: 0,
+        },
+    )
+    await hass.async_block_till_done()
+    manager = switch.manager
+
+    light_group = "light.light_group"
+    member_light = "light.light_4"
+
+    # Verify the group is expanded and members are tracked
+    assert member_light in switch.lights, "Group members should be in switch.lights"
+
+    # 1. Simulate the group being turned off first
+    # This creates the on_to_off_event with a specific context
+    group_turn_off_context = Context(id="group_turn_off_context")
+    group_on_to_off_event = Event(
+        event_type=EVENT_STATE_CHANGED,
+        data={
+            ATTR_ENTITY_ID: light_group,
+            "old_state": State(light_group, STATE_ON),
+            "new_state": State(light_group, STATE_OFF),
+        },
+        context=group_turn_off_context,
+    )
+    manager.on_to_off_event[light_group] = group_on_to_off_event
+
+    # 2. Small delay to ensure member turn_on happens AFTER group turn_off
+    await asyncio.sleep(0.01)
+
+    # 3. Simulate a member light being turned on by a motion sensor
+    # This stores turn_on_event for the member with a DIFFERENT context
+    member_turn_on_context = Context(id="motion_sensor_turn_on")
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: member_light},
+        blocking=True,
+        context=member_turn_on_context,
+    )
+    await hass.async_block_till_done()
+
+    # Verify turn_on_event was stored for the member
+    assert (
+        manager.turn_on_event.get(member_light) is not None
+    ), "turn_on_event should be stored for member light"
+
+    # Verify the member's turn_on happened after the group's on_to_off
+    assert (
+        manager.turn_on_event[member_light].time_fired
+        > group_on_to_off_event.time_fired
+    ), "Member turn_on should happen after group on_to_off"
+
+    # 4. Create an off→on event for the GROUP with the SAME context as turn_off
+    # This simulates HA reusing the turn_off context ID (the bug scenario!)
+    off_to_on_event = Event(
+        event_type=EVENT_STATE_CHANGED,
+        data={
+            ATTR_ENTITY_ID: light_group,
+            "old_state": State(light_group, STATE_OFF),
+            "new_state": State(light_group, STATE_ON),
+        },
+        context=group_turn_off_context,  # SAME context as turn_off - this is the key!
+    )
+    manager.off_to_on_event[light_group] = off_to_on_event
+
+    # Verify context IDs match (this is what triggers the bug)
+    assert (
+        off_to_on_event.context.id == group_on_to_off_event.context.id
+    ), "Context IDs should match to simulate the HA context reuse scenario"
+
+    # 5. Call just_turned_off - it should return False (allow adaptation)
+    # because a member light was turned on after the group was turned off.
+    #
+    # BUG: Currently returns True because the context ID match check
+    # at line 2804 returns early, before the member check at line 2824.
+    result = await manager.just_turned_off(light_group)
+
+    assert result is False, (
+        "just_turned_off should return False (allow adaptation) for light groups "
+        "when a member was turned on after the group was turned off, EVEN IF "
+        "the context IDs match due to HA's context reuse behavior. "
+        "The member's turn_on_event explains why the group turned on."
+    )


### PR DESCRIPTION
## Summary

Fixes issue where light groups don't adapt when child lights are turned on by an automation (e.g., motion sensor).

## What Happened (from user's debug logs)

The user reported that their bedroom lights turned on **red** (previous color from a scene) instead of being adapted by Adaptive Lighting when a motion sensor triggered them.

**Timeline from debug logs:**

```
13:49:58.813  light.turn_off('light.bedroom_lights') with context 01KET2ZVMX4WWB95GX2XTDBW8A
13:49:59.117  State change ON→OFF for bedroom_lights with context 01KET2ZVMX4WWB95GX2XTDBW8A
13:50:00.534  light.turn_on('night_lights', 'ceiling_lights') with context 01KET2ZXANFR7KSPP60WVMPK8H
13:50:00.807  State change OFF→ON for bedroom_lights with context 01KET2ZVMX4WWB95GX2XTDBW8A  ← REUSED!
13:50:00.807  "This is probably a false positive" → Adaptation CANCELLED
```

**The problem**: When the motion sensor turned on the child lights (`night_lights`, `ceiling_lights`), the parent group (`bedroom_lights`) also turned on as a side effect. But Home Assistant **reused the old turn_off context ID** for the parent's state change.

The `just_turned_off()` function saw matching context IDs and incorrectly assumed this was a "polling artifact" (HA briefly reporting ON during a turn_off transition), so it cancelled adaptation.

## Root Cause

```python
# OLD CODE in just_turned_off():
if off_to_on_event.context.id == on_to_off_event.context.id:
    _LOGGER.debug("This is probably a false positive.")
    return True  # ← Blocks adaptation!
```

This check was designed to catch polling artifacts, but it didn't account for light groups where HA reuses context IDs.

## Fix

Use **causality-based detection** instead of just context ID matching:

1. **Enhanced `_off_to_on_state_event_is_from_turn_on()`** to check if any member light of a group has a `turn_on_event` that happened after the group's on→off event:

```python
# NEW CODE:
if state is not None and _is_light_group(state):
    member_lights = state.attributes.get("entity_id", [])
    for member in member_lights:
        member_turn_on = self.turn_on_event.get(member)
        if member_turn_on is not None:
            if member_turn_on.time_fired > on_to_off_event.time_fired:
                _LOGGER.debug(
                    "Light group '%s' turned on because member '%s' was turned on",
                    entity_id, member,
                )
                return True  # ← This is a valid turn-on, not a polling artifact!
```

2. **Restructured `just_turned_off()`** to check for turn_on events BEFORE checking for matching context IDs. Only treat matching context IDs as a false positive if no turn_on event explains the state change.

## Why This is Robust

| Old Approach (fragile) | New Approach (causality-based) |
|------------------------|--------------------------------|
| Magic time threshold | Actual causal relationship |
| Fails with different timing | Works regardless of timing |
| No explanation in logs | Clear log: "group turned on because member X was turned on" |

## Expected Behavior After Fix

With the user's scenario:
1. Motion sensor turns on child lights (`night_lights`, `ceiling_lights`)
2. `turn_on_event` is stored for these members
3. Parent group (`bedroom_lights`) turns on as side effect
4. `_off_to_on_state_event_is_from_turn_on()` checks group members
5. Finds `turn_on_event` for `night_lights` that happened after group's turn_off
6. Returns `True` → `just_turned_off()` returns `False` → **Adaptation proceeds!**

## Test Plan

- [x] Added `test_just_turned_off_context_reuse_with_light_groups` - verifies light group members' turn_on events are detected
- [x] Added `test_just_turned_off_polling_artifact_still_detected` - verifies polling artifacts are still correctly blocked
- [ ] CI tests pass

Fixes #1378