### PR TITLE
build: fix tasks not executing in dev container

### DIFF
--- a/scripts/develop
+++ b/scripts/develop
@@ -17,4 +17,4 @@ fi
 export PYTHONPATH="${PYTHONPATH}:${PWD}/custom_components"
 
 # Start Home Assistant
-hass --config "${PWD}/config" --debug
+uv run hass --config "${PWD}/config" --debug

--- a/scripts/lint
+++ b/scripts/lint
@@ -4,4 +4,4 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-pre-commit run --all-files
+uv run pre-commit run --all-files


### PR DESCRIPTION
Running tasks in VSCode inside the dev container didn't work because the venv didn't get initialized in non-interactive task terminals.