### PR TITLE
Add core/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 # Home Assistant configuration
 config/*
 !config/configuration.yaml
+
+# Home Assistant core
+core/


### PR DESCRIPTION
Per tests/README.md, this is needed for running tests with Docker. So, we should ignore it.