### PR TITLE
fix: merge last_service_data across split calls to fix detect_non_ha_changes with separate_turn_on_commands

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1356,10 +1356,6 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
                 data.context.id,
             )
             light = service_data[ATTR_ENTITY_ID]
-            # Merge rather than overwrite so that split calls (separate_turn_on_commands)
-            # accumulate all adapted attributes. Without this, the last split call
-            # (e.g. color) overwrites the first (e.g. brightness), causing
-            # detect_non_ha_changes to miss manual brightness changes entirely.
             self.manager.last_service_data[light] = {
                 **self.manager.last_service_data.get(light, {}),
                 **service_data,

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1356,7 +1356,14 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
                 data.context.id,
             )
             light = service_data[ATTR_ENTITY_ID]
-            self.manager.last_service_data[light] = service_data
+            # Merge rather than overwrite so that split calls (separate_turn_on_commands)
+            # accumulate all adapted attributes. Without this, the last split call
+            # (e.g. color) overwrites the first (e.g. brightness), causing
+            # detect_non_ha_changes to miss manual brightness changes entirely.
+            self.manager.last_service_data[light] = {
+                **self.manager.last_service_data.get(light, {}),
+                **service_data,
+            }
             await self.hass.services.async_call(
                 LIGHT_DOMAIN,
                 SERVICE_TURN_ON,

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1696,7 +1696,7 @@ async def test_change_switch_settings_service(hass):
 
 async def test_cancellable_service_calls_task(hass):
     """Test the creation and execution of the task that wraps adaptation service calls."""
-    (light, *_) = await setup_lights(hass)
+    light, *_ = await setup_lights(hass)
     _, switch = await setup_switch(hass, {CONF_SEPARATE_TURN_ON_COMMANDS: True})
     context = switch.create_context("test")
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2962,6 +2962,18 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
     #    populates last_service_data.
     await update(force=True)
 
+    # Verify the fix: both attributes must survive the two split calls.
+    # Without the fix, the color call overwrites the brightness call, so
+    # last_service_data would contain only color_temp at this point.
+    last_sd = switch.manager.last_service_data.get(ENTITY_LIGHT_1)
+    assert last_sd is not None, "last_service_data not populated after force adapt"
+    assert ATTR_BRIGHTNESS in last_sd, (
+        f"brightness missing from last_service_data after split calls: {last_sd}"
+    )
+    assert ATTR_COLOR_TEMP_KELVIN in last_sd or ATTR_RGB_COLOR in last_sd, (
+        f"color missing from last_service_data after split calls: {last_sd}"
+    )
+
     al_brightness = light._brightness  # brightness AL just set
 
     # Reset manual control so the detect_non_ha_changes path starts clean.
@@ -2996,6 +3008,15 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
         #    delta is detected → manual_control is set.  Without the fix, brightness
         #    is absent → comparison skipped → manual_control stays NONE.
         await update(force=False)
+
+        assert LightControlAttributes.BRIGHTNESS in switch.manager.manual_control.get(
+            ENTITY_LIGHT_1, LightControlAttributes.NONE
+        ), (
+            f"Expected brightness to be marked as manually controlled after the "
+            f"Zigbee direct-change was simulated, but manual_control="
+            f"{switch.manager.manual_control.get(ENTITY_LIGHT_1)}. "
+            f"last_service_data={switch.manager.last_service_data.get(ENTITY_LIGHT_1)}"
+        )
 
         # 4. Second AL interval: this is what the user actually sees.
         #    With the fix: AL respects manual_control and does NOT send turn_on →

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2917,27 +2917,13 @@ async def test_adapt_only_on_bare_turn_on_respects_pause_changed_mode(hass, inte
 
 
 async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
-    """Regression test: detect_non_ha_changes must work with separate_turn_on_commands.
+    """Regression test for detect_non_ha_changes with separate_turn_on_commands.
 
-    End-to-end scenario: an IKEA RODRET (or similar) switch is directly bound to a
-    Zigbee bulb.  When the user adjusts brightness on the knob, the bulb changes
-    immediately via Zigbee — no HA service call is made.  ZHA later reports the new
-    brightness to HA via an attribute report (async_update_entity).
-
-    Expected behaviour: on the next AL adaptation interval AL notices the brightness
-    differs from what it last set, marks the light as manually controlled, and does
-    NOT override the user's brightness.
-
-    Buggy behaviour (before fix): AL re-adapts the light every interval and overrides
-    the manually set brightness — exactly what the user observed.
-
-    Root cause: with separate_turn_on_commands=True each cycle makes two light.turn_on
-    calls (brightness, then color).  The second call overwrote last_service_data,
-    dropping brightness.  _attributes_have_changed then saw old_brightness=None and
-    silently skipped the comparison, so the manual change was never detected.
-
-    Fix: merge rather than overwrite last_service_data so brightness survives both
-    split calls and the comparison runs correctly.
+    With separate_turn_on_commands=True, each adaptation cycle makes two sequential
+    light.turn_on calls (brightness, then color). If the second call overwrites
+    last_service_data instead of merging, brightness is dropped — and
+    _attributes_have_changed silently skips the brightness comparison, so a direct
+    Zigbee brightness change is never detected as manual control.
     """
     switch, (light, *_) = await setup_lights_and_switch(
         hass,
@@ -2958,15 +2944,10 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
         )
         await hass.async_block_till_done()
 
-    # 1. Let AL adapt the light — produces two split light.turn_on calls and
-    #    populates last_service_data.
     await update(force=True)
 
-    # Verify the fix: both attributes must survive the two split calls.
-    # Without the fix, the color call overwrites the brightness call, so
-    # last_service_data would contain only color_temp at this point.
     last_sd = switch.manager.last_service_data.get(ENTITY_LIGHT_1)
-    assert last_sd is not None, "last_service_data not populated after force adapt"
+    assert last_sd is not None
     assert (
         ATTR_BRIGHTNESS in last_sd
     ), f"brightness missing from last_service_data after split calls: {last_sd}"
@@ -2974,65 +2955,34 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
         ATTR_COLOR_TEMP_KELVIN in last_sd or ATTR_RGB_COLOR in last_sd
     ), f"color missing from last_service_data after split calls: {last_sd}"
 
-    al_brightness = light._brightness  # brightness AL just set
-
-    # Reset manual control so the detect_non_ha_changes path starts clean.
+    al_brightness = light._brightness
     switch.manager.manual_control[ENTITY_LIGHT_1] = LightControlAttributes.NONE
 
-    # 2. Simulate the Zigbee device directly changing brightness on the bulb.
-    #    In the real scenario the RODRET sends a Zigbee Level Control command
-    #    directly to the bulb with no HA service call; ZHA then receives the
-    #    attribute report and updates the entity state via async_update_entity.
-    #
-    #    significant_change() calls async_update_entity() so the entity's own
-    #    update method runs before the state is read.  For these mock template
-    #    lights that re-evaluates the template and would reset brightness back
-    #    to whatever AL last set.  We patch async_update_entity to instead just
-    #    flush _brightness to HA state — exactly what a real ZHA entity does
-    #    when it reports new hardware state from a Zigbee attribute report.
     manual_brightness = (
         al_brightness - 120 if al_brightness >= 120 else al_brightness + 120
     )
     light._brightness = manual_brightness
 
     async def _flush_attr_state(hass, entity_id):
-        """Write current _brightness to HA state (mimics ZHA attribute report)."""
+        """Mimic a ZHA attribute report: write current hardware state to HA."""
         light.async_write_ha_state()
 
     with patch(
         "homeassistant.components.adaptive_lighting.switch.async_update_entity",
         new=AsyncMock(side_effect=_flush_attr_state),
     ):
-        # 3. First AL interval: detect_non_ha_changes compares current state against
-        #    last_service_data.  With the fix, brightness is present and the large
-        #    delta is detected → manual_control is set.  Without the fix, brightness
-        #    is absent → comparison skipped → manual_control stays NONE.
         await update(force=False)
 
         assert LightControlAttributes.BRIGHTNESS in switch.manager.manual_control.get(
             ENTITY_LIGHT_1,
             LightControlAttributes.NONE,
         ), (
-            f"Expected brightness to be marked as manually controlled after the "
-            f"Zigbee direct-change was simulated, but manual_control="
-            f"{switch.manager.manual_control.get(ENTITY_LIGHT_1)}. "
+            f"manual_control={switch.manager.manual_control.get(ENTITY_LIGHT_1)}, "
             f"last_service_data={switch.manager.last_service_data.get(ENTITY_LIGHT_1)}"
         )
 
-        # 4. Second AL interval: this is what the user actually sees.
-        #    With the fix: AL respects manual_control and does NOT send turn_on →
-        #      light._brightness stays at manual_brightness.
-        #    Without the fix: manual_control is NONE → AL re-adapts → sends
-        #      turn_on(brightness=al_brightness) → light goes back to al_brightness.
-        #      This is the override the user observed.
         await update(force=False)
 
     assert light._brightness == manual_brightness, (
-        f"AL overrode the manually set brightness ({manual_brightness}) with its "
-        f"own target ({al_brightness}). "
-        f"The user's direct-Zigbee brightness change was not respected. "
-        f"Likely cause: last_service_data is missing brightness after "
-        f"separate_turn_on_commands split calls, so _attributes_have_changed skipped "
-        f"the comparison and manual_control was never set. "
-        f"last_service_data={switch.manager.last_service_data.get(ENTITY_LIGHT_1)}"
+        f"AL overrode manual brightness {manual_brightness} with {al_brightness}"
     )

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2983,6 +2983,6 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
 
         await update(force=False)
 
-    assert light._brightness == manual_brightness, (
-        f"AL overrode manual brightness {manual_brightness} with {al_brightness}"
-    )
+    assert (
+        light._brightness == manual_brightness
+    ), f"AL overrode manual brightness {manual_brightness} with {al_brightness}"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2967,12 +2967,12 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
     # last_service_data would contain only color_temp at this point.
     last_sd = switch.manager.last_service_data.get(ENTITY_LIGHT_1)
     assert last_sd is not None, "last_service_data not populated after force adapt"
-    assert ATTR_BRIGHTNESS in last_sd, (
-        f"brightness missing from last_service_data after split calls: {last_sd}"
-    )
-    assert ATTR_COLOR_TEMP_KELVIN in last_sd or ATTR_RGB_COLOR in last_sd, (
-        f"color missing from last_service_data after split calls: {last_sd}"
-    )
+    assert (
+        ATTR_BRIGHTNESS in last_sd
+    ), f"brightness missing from last_service_data after split calls: {last_sd}"
+    assert (
+        ATTR_COLOR_TEMP_KELVIN in last_sd or ATTR_RGB_COLOR in last_sd
+    ), f"color missing from last_service_data after split calls: {last_sd}"
 
     al_brightness = light._brightness  # brightness AL just set
 
@@ -3010,7 +3010,8 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
         await update(force=False)
 
         assert LightControlAttributes.BRIGHTNESS in switch.manager.manual_control.get(
-            ENTITY_LIGHT_1, LightControlAttributes.NONE
+            ENTITY_LIGHT_1,
+            LightControlAttributes.NONE,
         ), (
             f"Expected brightness to be marked as manually controlled after the "
             f"Zigbee direct-change was simulated, but manual_control="

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2947,7 +2947,7 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
     await update(force=True)
 
     last_sd = switch.manager.last_service_data.get(ENTITY_LIGHT_1)
-    assert last_sd is not None
+    assert last_sd is not None, "last_service_data not set after force adapt"
     assert (
         ATTR_BRIGHTNESS in last_sd
     ), f"brightness missing from last_service_data after split calls: {last_sd}"


### PR DESCRIPTION
## Bug

`separate_turn_on_commands: true` causes each adaptation cycle to make two sequential `light.turn_on` calls — one for brightness, one for color. Each call overwrote `last_service_data`, so after the color call, brightness was gone.

When `detect_non_ha_changes: true` checks for manual changes, `_attributes_have_changed` reads brightness from `last_service_data`. With brightness absent, the comparison is silently skipped — so brightness changes made directly on the bulb (e.g. via a Zigbee-bound switch bypassing HA) were never detected, and AL kept overriding them.

## Fix

Merge into `last_service_data` instead of overwriting, so attributes accumulate across split calls:

```python
self.manager.last_service_data[light] = {
    **self.manager.last_service_data.get(light, {}),
    **service_data,
}
```

`reset()` clears `last_service_data` when a light turns off, so there is no stale-data concern.

## Testing

Added `test_detect_non_ha_changes_with_separate_turn_on_commands` in `tests/test_switch.py`, which:
1. Force-adapts and asserts `last_service_data` contains both `brightness` and `color_temp_kelvin` after the split calls
2. Simulates a direct Zigbee brightness change
3. Asserts the light is marked `manually_controlled=BRIGHTNESS` on the next interval
4. Asserts AL does not override the manual brightness on the following interval

Live-tested on HAOS 17.0 / HA Core 2026.2.1 with an IKEA TRADFRI bulb + RODRET switch. Before the fix, AL overrode manual brightness every interval. After the fix, the manual change is detected and respected.