### PR TITLE
Stagger adaptation interval start with a per-switch offset

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import hashlib
 import logging
 import zoneinfo
 from copy import deepcopy
@@ -62,6 +63,7 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.helpers.event import (
     EventStateChangedData,
+    async_call_later,
     async_track_state_change_event,
     async_track_time_interval,
 )
@@ -1066,6 +1068,27 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
         self.remove_listeners.append(remove_sleep)
         self._expand_light_groups()
 
+    def _stagger_offset(self, adaptation_interval: timedelta) -> timedelta:
+        """Return a deterministic, per-switch offset to desynchronize updates.
+
+        When many Adaptive Lighting switches share (roughly) the same interval,
+        they tend to start their periodic update cycle at the same moment
+        (e.g., right after Home Assistant starts), causing every switch to call
+        `light.turn_on` in lockstep. On installations with many lights this can
+        saturate the network (notably Zigbee), see
+        https://github.com/basnijholt/adaptive-lighting/issues/939.
+
+        The offset is derived from a hash of this switch's unique/entity name
+        rather than `random.random()` so that it is stable across Home Assistant
+        restarts and reloads (a given switch always gets the same phase) while
+        still being effectively uncorrelated between different switches. It is
+        bounded to `[0, adaptation_interval)` so it only ever shifts the phase
+        of the update cycle, never the effective interval between updates.
+        """
+        digest = hashlib.sha256(self.unique_id.encode()).digest()
+        fraction = int.from_bytes(digest[:8], byteorder="big") / 2**64
+        return adaptation_interval * fraction
+
     def _update_time_interval_listener(self) -> None:
         """Create or recreate the adaptation interval listener.
 
@@ -1086,11 +1109,27 @@ class AdaptiveSwitch(SwitchEntity, RestoreEntity):
             + timedelta(seconds=processing_overhead_time)
         )
 
-        self.remove_interval = async_track_time_interval(
-            self.hass,
-            action=self._async_update_at_interval_action,
-            interval=adaptation_interval,
-        )
+        def _start_periodic_listener(_now: datetime.datetime | None = None) -> None:
+            self.remove_interval = async_track_time_interval(
+                self.hass,
+                action=self._async_update_at_interval_action,
+                interval=adaptation_interval,
+            )
+
+        # Delay the first tick by a per-switch offset so that switches with the
+        # same interval don't all adapt their lights at the same time. Since
+        # `async_track_time_interval` schedules subsequent ticks relative to
+        # when it was started, this offset persists for the lifetime of the
+        # listener without changing the interval itself.
+        offset = self._stagger_offset(adaptation_interval)
+        if offset > timedelta(0):
+            self.remove_interval = async_call_later(
+                self.hass,
+                offset.total_seconds(),
+                _start_periodic_listener,
+            )
+        else:
+            _start_periodic_listener()
 
     def _call_on_remove_callbacks(self) -> None:
         """Call callbacks registered by async_on_remove."""

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1551,6 +1551,57 @@ async def test_async_update_at_interval_action(hass):
     await switch._async_update_at_interval_action()
 
 
+async def test_stagger_offset_deterministic_and_bounded(hass):
+    """Test '_stagger_offset' desynchronizes switches without changing the interval.
+
+    See https://github.com/basnijholt/adaptive-lighting/issues/939: when many
+    Adaptive Lighting switches share the same interval, they can all call
+    'light.turn_on' at the same moment, overloading (Zigbee) networks. Each
+    switch should get its own stable phase offset, bounded to the interval.
+    """
+    interval = datetime.timedelta(seconds=90)
+
+    _, switch_a = await setup_switch(hass, {CONF_NAME: "switch_a"})
+    _, switch_b = await setup_switch(hass, {CONF_NAME: "switch_b"})
+
+    # Stable/deterministic: repeated calls for the same switch return the same offset.
+    offset_a_1 = switch_a._stagger_offset(interval)
+    offset_a_2 = switch_a._stagger_offset(interval)
+    assert offset_a_1 == offset_a_2
+
+    # Different switches (different unique_id/name) get different phases.
+    offset_b = switch_b._stagger_offset(interval)
+    assert offset_a_1 != offset_b
+
+    # Bounded: the offset only ever shifts the phase, never exceeds the interval.
+    for offset in (offset_a_1, offset_b):
+        assert datetime.timedelta(0) <= offset < interval
+
+
+async def test_update_time_interval_listener_uses_stagger_offset(hass):
+    """Test that the interval listener defers its first tick using the stagger offset."""
+    switch_module = "homeassistant.components.adaptive_lighting.switch"
+    with (
+        patch(
+            f"{switch_module}.AdaptiveSwitch._stagger_offset",
+            return_value=datetime.timedelta(seconds=5),
+        ) as mock_offset,
+        patch(f"{switch_module}.async_call_later") as mock_call_later,
+        patch(f"{switch_module}.async_track_time_interval") as mock_track_interval,
+    ):
+        _, switch = await setup_switch(hass, {})
+        assert mock_offset.called
+        mock_call_later.assert_called_once()
+        assert mock_call_later.call_args.args[1] == 5
+        mock_track_interval.assert_not_called()
+
+        # Once the delayed call fires, the regular periodic listener is started.
+        delayed_action = mock_call_later.call_args.args[2]
+        delayed_action(dt_util.utcnow())
+        mock_track_interval.assert_called_once()
+        assert switch.remove_interval is mock_track_interval.return_value
+
+
 @pytest.mark.parametrize("separate_turn_on_commands", (True, False))
 async def test_separate_turn_on_commands(hass, separate_turn_on_commands):
     """Test 'separate_turn_on_commands' argument."""


### PR DESCRIPTION
## Problem

Adaptive Lighting switches created together use the same periodic cadence, so their recurring updates can remain synchronized and create bursts of service calls.

## Change

- Derive a deterministic per-switch offset from a SHA-256 hash of its unique ID.
- Delay periodic-listener registration by that offset. Turn-on adaptation remains immediate; the first periodic update occurs after the interval plus offset, and later updates keep the configured interval.
- Run delayed listener registration on Home Assistant's event loop.

This provides best-effort spreading between switches. It does not enforce a global rate limit or spread lights managed by one switch.

## Validation

- Deterministic, distinct, bounded offset coverage
- Disable cancels pending registration
- Reconfigure replaces pending registration
- Real Home Assistant timer coverage for interval-plus-offset first tick and interval cadence afterward
- Full integration suite: 257 passed on Home Assistant 2026.4.3 and 257 on 2026.10.0.dev0, with Python 3.14.2
- Repository hooks passed

Closes #939
