### PR TITLE
fix: re-adapt lights right after the auto-reset timer fires (timer cancelled its own callback)

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -2254,7 +2254,6 @@ class AdaptiveLightingManager:
                     transition=switch.initial_transition,
                     force=True,
                 )
-            assert self.manual_control[light] == LightControlAttributes.NONE
 
         self._handle_timer(light, self.auto_reset_manual_control_timers, delay, reset)
 
@@ -2995,9 +2994,17 @@ class _AsyncSingleShotTimer:
 
     def cancel(self) -> None:
         """Cancel the timer."""
-        if self.task:
+        # Never cancel the task that is currently running our own callback, e.g.
+        # when the auto-reset callback calls manager.reset(), which cancels the
+        # timer it is running in. That used to silently cancel the rest of the
+        # callback (the re-adaptation), see issue #1233.
+        try:
+            current_task = asyncio.current_task()
+        except RuntimeError:  # no running event loop
+            current_task = None
+        if self.task and self.task is not current_task:
             self.task.cancel()
-            self.callback = None
+        self.callback = None
 
     def remaining_time(self) -> float:
         """Return the remaining time before the timer expires."""

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -913,11 +913,27 @@ async def test_auto_reset_manual_control(hass):
         switch.extra_state_attributes["autoreset_time_remaining"][light.entity_id] > 0
     )
     await update()
+    # The auto reset must also re-adapt the light right away, not only clear the
+    # flag. Collect the 'light.turn_on' calls made with the 'autoreset' context.
+    autoreset_calls: list[Event] = []
+
+    async def _on_call_service(event: Event) -> None:
+        if (
+            event.data.get("domain") == LIGHT_DOMAIN
+            and event.data.get("service") == SERVICE_TURN_ON
+            and is_our_context(event.context, "autoreset")
+        ):
+            autoreset_calls.append(event)
+
+    remove_listener = hass.bus.async_listen(EVENT_CALL_SERVICE, _on_call_service)
     await asyncio.sleep(0.3)  # Should be enough time for auto reset
+    await hass.async_block_till_done()
+    remove_listener()
     assert not manual_control[light.entity_id], (light, manual_control)
     assert (
         light.entity_id not in switch.extra_state_attributes["autoreset_time_remaining"]
     )
+    assert autoreset_calls, "auto reset did not re-adapt the light"
 
     # Do a couple of quick changes and check that light is not reset
     for i in range(3):


### PR DESCRIPTION
Hi! I ran into #1233 myself (Adaptive Lighting 1.31.0, HA 2026.8.2, IKEA bulbs over Matter) and spent an evening digging into it. I think I found the cause, so here's a small patch.

**What I saw**

I set `autoreset_control_seconds` to 5 to test it, turned a light on, changed its colour temperature by hand and watched the `call_service` events. The `manual_control` flag was cleared exactly 5 seconds later - so the timer itself is fine - but no `light.turn_on` from AL followed. The light only changed at the next `interval` pass (90 s here), and then with the normal 45 s `transition`. So it took anywhere between ~45 s and a bit over 2 minutes to come back, which for most people just looks like "autoreset doesn't work".

**Why**

In `set_manual_control_attributes()` the timer callback `reset()` starts with `self.reset(light)`. `AdaptiveLightingManager.reset()` pops the auto-reset timer and calls `timer.cancel()`, and `_AsyncSingleShotTimer.cancel()` does `self.task.cancel()` - but at that point `self.task` *is* the task that is running the callback. So the timer cancels itself. The synchronous bit (clearing the flag, writing the switch state) has already happened, which is why the attribute looks right, but the `CancelledError` hits at the next real `await` inside `_update_attrs_and_maybe_adapt_lights()` (the `asyncio.gather` that runs `_adapt_light`) and the re-adaptation never goes out. Nothing ends up in the log because a cancelled task is silent, and the `assert` at the end of the callback is simply never reached.

**The change**

- `_AsyncSingleShotTimer.cancel()` no longer cancels the task that is currently running its own callback (`self.task is not asyncio.current_task()`), with a guard for "no running loop". Everything else that calls `cancel()` (`_handle_timer` with `delay=None`, `manager.reset()` from the event listeners / services, the test cleanup fixture) still behaves exactly as before - the only situation that changes is the callback cancelling itself. `start()` is untouched, and the transition timer's callback is a no-op so nothing changes there either.
- Dropped the `assert self.manual_control[light] == LightControlAttributes.NONE` at the end of the callback. It was unreachable before; now that the callback actually finishes it could trip if someone changes the light again while the 1 s re-adaptation is running, and that would just produce an unhandled-exception log line.
- Extended `test_auto_reset_manual_control` to check that a `light.turn_on` with the `autoreset` context is sent after the reset.

**Tested on my own setup**

Same test as above, after applying this to 1.31.0 and restarting: manual change at 10:32:05.1 -> flag cleared at 10:32:10.13 *and* `light.turn_on ... transition=1` with an `...:autoreset:...` context at the same moment -> bulbs back at the adaptive colour at 10:32:11.3. About 6 seconds total instead of a minute or more. Before the patch, same procedure: flag cleared at +5 s, then nothing until the interval pass 16 s later, followed by the 45 s fade.

I don't have a local pytest setup for HA, so the test change is only verified by CI - happy to adjust if something's off.

Fixes #1233
