### PR TITLE
Preserve Home Assistant area target exclusions

### DIFF
--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1831,21 +1831,14 @@ class AdaptiveLightingManager:
         return context
 
     def _is_service_light(self, entity_id: str) -> bool:
-        """Return True for "service" lights excluded from *indirect* turn-on.
+        """Return True for "service" lights excluded from area turn-on.
 
         Home Assistant itself excludes entities with an `entity_category`
         (config/diagnostic) from area/device/label service-call expansion
         (see core commit "Exclude hidden entities from targets"), so a
-        `light.turn_on` targeting an area never reaches them. When a service
-        light is *explicitly* named in `entity_id`, however, HA does turn it
-        on — so AL must too (handled by the caller, which only applies this
-        filter to indirectly-expanded entities).
-
-        A light with a category set is not normal room lighting and must not be
-        turned on by the intercept when reached via area/device/label
-        expansion. Such lights stay in AL's `lights` (so they are still adapted
-        when on) but are excluded from the intercept-driven turn-on in that
-        case.
+        `light.turn_on` targeting an area never reaches them. We mirror that
+        rule via the entity registry: a light with a category set is not
+        normal room lighting and must not be turned on by the intercept.
 
         We read the category from the entity registry (authoritative) rather
         than `state.attributes`, because registry-only attributes are not
@@ -1861,7 +1854,6 @@ class AdaptiveLightingManager:
         self,
         entity_ids: list[str],
         data: ServiceData,
-        direct_entity_ids: set[str],
     ) -> tuple[AdaptiveSwitchMap, list[str]]:
         # Create a mapping from switch to entity IDs
         # AdaptiveSwitch → entity_ids mapping
@@ -1912,20 +1904,6 @@ class AdaptiveLightingManager:
                         self.hass.states.is_state(entity_id, STATE_ON),
                         self.manual_control.get(entity_id, False),
                         switch._intercept,
-                    )
-                    skipped.append(entity_id)
-                # Only service lights reached via indirect area/device/label
-                # expansion are excluded; explicitly targeted ones are kept.
-                elif (
-                    self._is_service_light(
-                        entity_id,
-                    )
-                    and entity_id not in direct_entity_ids
-                ):
-                    _LOGGER.debug(
-                        "Service light '%s' excluded from intercept "
-                        "turn-on (indirect target; kept managed for adaptation)",
-                        entity_id,
                     )
                     skipped.append(entity_id)
                 else:
@@ -2030,13 +2008,9 @@ class AdaptiveLightingManager:
         # we skip them and rely on the followup call that HA will make
         # with the expanded entity IDs.
 
-        direct_entity_ids = set(
-            cv.ensure_list_csv(service_data.get(ATTR_ENTITY_ID, [])),
-        )
         switch_to_eids, skipped = self._separate_entity_ids(
             entity_ids,
             service_data,
-            direct_entity_ids,
         )
 
         (
@@ -2114,27 +2088,16 @@ class AdaptiveLightingManager:
         # area/label expansion, so it deliberately leaves them off; AL must
         # not turn them on either. They remain in `self.lights` (if managed)
         # and are still adapted when on.
-        # Exclude service lights from the re-issue ONLY when they were reached
-        # via indirect (area/device/label) expansion. Explicitly targeted
-        # service lights are turned on to match HA's own direct-target behavior.
-        skipped_normal = [
-            eid
-            for eid in skipped
-            if not (self._is_service_light(eid) and eid not in direct_entity_ids)
-        ]
-        if skipped_normal and has_intercepted:
+        if skipped and has_intercepted:
             context = self.create_context("skipped")
             _LOGGER.debug(
                 "(5) _service_interceptor_turn_on_handler: calling `light.turn_on` "
-                "with skipped_normal='%s', service_data: '%s', context='%s'",
-                skipped_normal,
+                "with skipped='%s', service_data: '%s', context='%s'",
+                skipped,
                 service_data_copy,  # This is the original service data
                 context.id,
             )
-            service_data = {
-                ATTR_ENTITY_ID: skipped_normal,
-                **service_data_copy[CONF_PARAMS],
-            }
+            service_data = {ATTR_ENTITY_ID: skipped, **service_data_copy[CONF_PARAMS]}
             await self.hass.services.async_call(
                 LIGHT_DOMAIN,
                 SERVICE_TURN_ON,
@@ -2442,6 +2405,7 @@ class AdaptiveLightingManager:
                     entity_id
                     for entity_id in area_entity_ids
                     if entity_id.startswith(LIGHT_DOMAIN)
+                    and not self._is_service_light(entity_id)
                 ]
                 entity_ids.extend(eids)
                 _LOGGER.debug(

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1831,16 +1831,21 @@ class AdaptiveLightingManager:
         return context
 
     def _is_service_light(self, entity_id: str) -> bool:
-        """Return True for "service" lights excluded from area turn-on.
+        """Return True for "service" lights excluded from *indirect* turn-on.
 
         Home Assistant itself excludes entities with an `entity_category`
         (config/diagnostic) from area/device/label service-call expansion
         (see core commit "Exclude hidden entities from targets"), so a
-        `light.turn_on` targeting an area never reaches them. We mirror that
-        rule via the entity registry: a light with a category set is not
-        normal room lighting and must not be turned on by the intercept. Such
-        lights stay in AL's `lights` (so they are still adapted when on) but
-        are excluded from the intercept-driven turn-on.
+        `light.turn_on` targeting an area never reaches them. When a service
+        light is *explicitly* named in `entity_id`, however, HA does turn it
+        on — so AL must too (handled by the caller, which only applies this
+        filter to indirectly-expanded entities).
+
+        A light with a category set is not normal room lighting and must not be
+        turned on by the intercept when reached via area/device/label
+        expansion. Such lights stay in AL's `lights` (so they are still adapted
+        when on) but are excluded from the intercept-driven turn-on in that
+        case.
 
         We read the category from the entity registry (authoritative) rather
         than `state.attributes`, because registry-only attributes are not
@@ -1856,6 +1861,7 @@ class AdaptiveLightingManager:
         self,
         entity_ids: list[str],
         data: ServiceData,
+        direct_entity_ids: set[str],
     ) -> tuple[AdaptiveSwitchMap, list[str]]:
         # Create a mapping from switch to entity IDs
         # AdaptiveSwitch → entity_ids mapping
@@ -1909,11 +1915,17 @@ class AdaptiveLightingManager:
                     )
                     skipped.append(entity_id)
                 else:
-                    is_service = self._is_service_light(entity_id)
+                    # Only exclude service lights that were reached via
+                    # indirect (area/device/label) expansion. When a service
+                    # light is *explicitly* targeted via `entity_id`, HA turns
+                    # it on, so AL must too.
+                    is_service = self._is_service_light(entity_id) and (
+                        entity_id not in direct_entity_ids
+                    )
                     if is_service:
                         _LOGGER.debug(
                             "Service light '%s' excluded from intercept "
-                            "turn-on (kept managed for adaptation)",
+                            "turn-on (indirect target; kept managed for adaptation)",
                             entity_id,
                         )
                         skipped.append(entity_id)
@@ -2019,9 +2031,13 @@ class AdaptiveLightingManager:
         # we skip them and rely on the followup call that HA will make
         # with the expanded entity IDs.
 
+        direct_entity_ids = set(
+            cv.ensure_list_csv(service_data.get(ATTR_ENTITY_ID, [])),
+        )
         switch_to_eids, skipped = self._separate_entity_ids(
             entity_ids,
             service_data,
+            direct_entity_ids,
         )
 
         (
@@ -2099,7 +2115,14 @@ class AdaptiveLightingManager:
         # area/label expansion, so it deliberately leaves them off; AL must
         # not turn them on either. They remain in `self.lights` (if managed)
         # and are still adapted when on.
-        skipped_normal = [eid for eid in skipped if not self._is_service_light(eid)]
+        # Exclude service lights from the re-issue ONLY when they were reached
+        # via indirect (area/device/label) expansion. Explicitly targeted
+        # service lights are turned on to match HA's own direct-target behavior.
+        skipped_normal = [
+            eid
+            for eid in skipped
+            if not (self._is_service_light(eid) and eid not in direct_entity_ids)
+        ]
         if skipped_normal and has_intercepted:
             context = self.create_context("skipped")
             _LOGGER.debug(

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1914,23 +1914,19 @@ class AdaptiveLightingManager:
                         switch._intercept,
                     )
                     skipped.append(entity_id)
-                else:
-                    # Only exclude service lights that were reached via
-                    # indirect (area/device/label) expansion. When a service
-                    # light is *explicitly* targeted via `entity_id`, HA turns
-                    # it on, so AL must too.
-                    is_service = self._is_service_light(entity_id) and (
-                        entity_id not in direct_entity_ids
+                # Only service lights reached via indirect area/device/label
+                # expansion are excluded; explicitly targeted ones are kept.
+                elif self._is_service_light(
+                    entity_id,
+                ) and entity_id not in direct_entity_ids:
+                    _LOGGER.debug(
+                        "Service light '%s' excluded from intercept "
+                        "turn-on (indirect target; kept managed for adaptation)",
+                        entity_id,
                     )
-                    if is_service:
-                        _LOGGER.debug(
-                            "Service light '%s' excluded from intercept "
-                            "turn-on (indirect target; kept managed for adaptation)",
-                            entity_id,
-                        )
-                        skipped.append(entity_id)
-                    if not is_service:
-                        switch_to_eids.setdefault(switch, []).append(entity_id)
+                    skipped.append(entity_id)
+                else:
+                    switch_to_eids.setdefault(switch, []).append(entity_id)
         return switch_to_eids, skipped
 
     def _correct_for_multi_light_intercept(

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1916,9 +1916,12 @@ class AdaptiveLightingManager:
                     skipped.append(entity_id)
                 # Only service lights reached via indirect area/device/label
                 # expansion are excluded; explicitly targeted ones are kept.
-                elif self._is_service_light(
-                    entity_id,
-                ) and entity_id not in direct_entity_ids:
+                elif (
+                    self._is_service_light(
+                        entity_id,
+                    )
+                    and entity_id not in direct_entity_ids
+                ):
                     _LOGGER.debug(
                         "Service light '%s' excluded from intercept "
                         "turn-on (indirect target; kept managed for adaptation)",

--- a/custom_components/adaptive_lighting/switch.py
+++ b/custom_components/adaptive_lighting/switch.py
@@ -1830,6 +1830,28 @@ class AdaptiveLightingManager:
         self._context_cnt += 1
         return context
 
+    def _is_service_light(self, entity_id: str) -> bool:
+        """Return True for "service" lights excluded from area turn-on.
+
+        Home Assistant itself excludes entities with an `entity_category`
+        (config/diagnostic) from area/device/label service-call expansion
+        (see core commit "Exclude hidden entities from targets"), so a
+        `light.turn_on` targeting an area never reaches them. We mirror that
+        rule via the entity registry: a light with a category set is not
+        normal room lighting and must not be turned on by the intercept. Such
+        lights stay in AL's `lights` (so they are still adapted when on) but
+        are excluded from the intercept-driven turn-on.
+
+        We read the category from the entity registry (authoritative) rather
+        than `state.attributes`, because registry-only attributes are not
+        always present on the recorded state.
+        """
+        ent_reg = entity_registry.async_get(self.hass)
+        entry = ent_reg.async_get(entity_id) if ent_reg is not None else None
+        if entry is None:
+            return False
+        return entry.entity_category is not None
+
     def _separate_entity_ids(
         self,
         entity_ids: list[str],
@@ -1887,7 +1909,16 @@ class AdaptiveLightingManager:
                     )
                     skipped.append(entity_id)
                 else:
-                    switch_to_eids.setdefault(switch, []).append(entity_id)
+                    is_service = self._is_service_light(entity_id)
+                    if is_service:
+                        _LOGGER.debug(
+                            "Service light '%s' excluded from intercept "
+                            "turn-on (kept managed for adaptation)",
+                            entity_id,
+                        )
+                        skipped.append(entity_id)
+                    if not is_service:
+                        switch_to_eids.setdefault(switch, []).append(entity_id)
         return switch_to_eids, skipped
 
     def _correct_for_multi_light_intercept(
@@ -1976,8 +2007,11 @@ class AdaptiveLightingManager:
             service_data,
         )
 
-        # Because `_service_interceptor_turn_on_single_light_handler` modifies the
-        # original service data, we need to make a copy of it to use in the `skipped` call
+        # The intercept below rewrites `call.data` to target only the managed
+        # lights (see `modify_service_data`), so HA's original `light.turn_on`
+        # handler will only turn on the managed lights. We therefore need a
+        # copy of the original service data to re-issue `turn_on` for the
+        # unmanaged (skipped) lights so they still come on.
         service_data_copy = deepcopy(service_data)
 
         entity_ids = self._get_entity_list(service_data)
@@ -2053,20 +2087,32 @@ class AdaptiveLightingManager:
                     transition=transition,
                 )
 
-        # Call light.turn_on service for skipped entities
-        if skipped:
-            if not has_intercepted:
-                assert set(skipped) == set(entity_ids)
-                return  # The call will be intercepted with the original data
-            # Call light turn_on service for skipped entities
+        # Re-issue `light.turn_on` for the skipped (unmanaged) lights so they
+        # still come on. The intercept rewrote `call.data` to target only the
+        # managed lights (see `modify_service_data`), so HA's original handler
+        # only turns on the managed ones; the unmanaged normal lights must be
+        # turned on explicitly here.
+        #
+        # IMPORTANT: "service" lights (entities with an `entity_category`,
+        # e.g. the Home Assistant Voice LED ring) are excluded from this
+        # re-issue. Home Assistant itself excludes such entities from
+        # area/label expansion, so it deliberately leaves them off; AL must
+        # not turn them on either. They remain in `self.lights` (if managed)
+        # and are still adapted when on.
+        skipped_normal = [eid for eid in skipped if not self._is_service_light(eid)]
+        if skipped_normal and has_intercepted:
             context = self.create_context("skipped")
             _LOGGER.debug(
-                "(5) _service_interceptor_turn_on_handler: calling `light.turn_on` with skipped='%s', service_data: '%s', context='%s'",
-                skipped,
+                "(5) _service_interceptor_turn_on_handler: calling `light.turn_on` "
+                "with skipped_normal='%s', service_data: '%s', context='%s'",
+                skipped_normal,
                 service_data_copy,  # This is the original service data
                 context.id,
             )
-            service_data = {ATTR_ENTITY_ID: skipped, **service_data_copy[CONF_PARAMS]}
+            service_data = {
+                ATTR_ENTITY_ID: skipped_normal,
+                **service_data_copy[CONF_PARAMS],
+            }
             await self.hass.services.async_call(
                 LIGHT_DOMAIN,
                 SERVICE_TURN_ON,
@@ -2074,6 +2120,10 @@ class AdaptiveLightingManager:
                 blocking=True,
                 context=context,
             )
+        # When `has_intercepted` is False there are no managed lights in this
+        # call, so `call.data` still carries the original area/label target and
+        # HA's own handler turns on the normal lights (and excludes service
+        # lights) — nothing to re-issue here.
 
     async def _service_interceptor_turn_on_single_light_handler(
         self,

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -3265,17 +3265,20 @@ async def test_service_light_excluded_from_area_intercept_turn_on(hass):
         CONF_INTERCEPT: True,
     }
     _, switch1 = await setup_switch(
-        hass, {CONF_NAME: "switch1", CONF_LIGHTS: [ENTITY_LIGHT_1], **defaults},
+        hass,
+        {CONF_NAME: "switch1", CONF_LIGHTS: [ENTITY_LIGHT_1], **defaults},
     )
     _, switch2 = await setup_switch(
-        hass, {CONF_NAME: "switch2", CONF_LIGHTS: [ENTITY_LIGHT_2], **defaults},
+        hass,
+        {CONF_NAME: "switch2", CONF_LIGHTS: [ENTITY_LIGHT_2], **defaults},
     )
     assert hass.states.get(switch1.entity_id).state == STATE_ON
     assert hass.states.get(switch2.entity_id).state == STATE_ON
 
     # Mark the unmanaged light as a "service" light (entity_category set).
     reg.async_update_entity(
-        ENTITY_LIGHT_3, entity_category=EntityCategory.CONFIG,
+        ENTITY_LIGHT_3,
+        entity_category=EntityCategory.CONFIG,
     )
     assert reg.async_get(ENTITY_LIGHT_3).entity_category == EntityCategory.CONFIG
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -3370,3 +3370,61 @@ async def test_service_light_excluded_from_area_intercept_toggle(hass):
     # The service light is excluded by HA's area expansion AND by AL's
     # re-issue filter, so it must remain off.
     assert hass.states.get(ENTITY_LIGHT_3).state == STATE_OFF
+
+
+async def test_service_light_turns_on_when_directly_targeted(hass):
+    """A directly targeted service light must still turn on.
+
+    Unlike area/device/label expansion, Home Assistant turns on a service
+    light (entity_category set) when it is *explicitly* named in `entity_id`.
+    AL must mirror that: a config-class light listed directly in a
+    `light.turn_on` call is turned on (matching HA), while the indirectly
+    expanded area case (see test_service_light_excluded_from_area_intercept_turn_on)
+    still leaves it off.
+    """
+    await setup_lights(hass)
+    mock_area_registry(hass)
+
+    reg = entity_registry.async_get(hass)
+    for light in (ENTITY_LIGHT_1, ENTITY_LIGHT_2, ENTITY_LIGHT_3):
+        entry = reg.async_get(light)
+        reg.async_get_or_create(LIGHT_DOMAIN, "template", entry.unique_id)
+        reg.async_update_entity(light, area_id="test-area")
+
+    defaults = {
+        CONF_SUNRISE_TIME: datetime.time(SUNRISE.hour),
+        CONF_SUNSET_TIME: datetime.time(SUNSET.hour),
+        CONF_INITIAL_TRANSITION: 0,
+        CONF_TRANSITION: 0,
+        CONF_DETECT_NON_HA_CHANGES: True,
+        CONF_INTERCEPT: True,
+    }
+    _, switch1 = await setup_switch(
+        hass, {CONF_NAME: "switch1", CONF_LIGHTS: [ENTITY_LIGHT_1], **defaults},
+    )
+    _, switch2 = await setup_switch(
+        hass, {CONF_NAME: "switch2", CONF_LIGHTS: [ENTITY_LIGHT_2], **defaults},
+    )
+    assert hass.states.get(switch1.entity_id).state == STATE_ON
+    assert hass.states.get(switch2.entity_id).state == STATE_ON
+
+    # Mark the unmanaged light as a "service" light (entity_category set).
+    reg.async_update_entity(
+        ENTITY_LIGHT_3, entity_category=EntityCategory.CONFIG,
+    )
+    assert reg.async_get(ENTITY_LIGHT_3).entity_category == EntityCategory.CONFIG
+
+    # Explicitly target all three lights (including the service light) by entity_id.
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: [ENTITY_LIGHT_1, ENTITY_LIGHT_2, ENTITY_LIGHT_3]},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # All three must be on: the managed lights are adapted, and the explicitly
+    # targeted service light is turned on to match HA's direct-target behavior.
+    assert hass.states.get(ENTITY_LIGHT_1).state == STATE_ON
+    assert hass.states.get(ENTITY_LIGHT_2).state == STATE_ON
+    assert hass.states.get(ENTITY_LIGHT_3).state == STATE_ON

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -3297,3 +3297,73 @@ async def test_service_light_excluded_from_area_intercept_turn_on(hass):
     # The service light is excluded by HA's area expansion AND by AL's
     # re-issue filter, so it must remain off.
     assert hass.states.get(ENTITY_LIGHT_3).state == STATE_OFF
+
+
+async def test_service_light_excluded_from_area_intercept_toggle(hass):
+    """A service light (entity_category set) in an area must stay off on toggle.
+
+    Regression test for #1510: when Adaptive Lighting intercepts an area
+    `light.toggle`, it must not re-issue `toggle`/`turn_on` for entities that
+    Home Assistant itself excludes from area expansion (entities with an
+    `entity_category`, e.g. the Home Assistant Voice LED ring).
+    The managed lights must still be toggled on and adapted.
+    """
+    await setup_lights(hass)
+    mock_area_registry(hass)
+
+    reg = entity_registry.async_get(hass)
+    for light in (ENTITY_LIGHT_1, ENTITY_LIGHT_2, ENTITY_LIGHT_3):
+        entry = reg.async_get(light)
+        reg.async_get_or_create(LIGHT_DOMAIN, "template", entry.unique_id)
+        reg.async_update_entity(light, area_id="test-area")
+
+    defaults = {
+        CONF_SUNRISE_TIME: datetime.time(SUNRISE.hour),
+        CONF_SUNSET_TIME: datetime.time(SUNSET.hour),
+        CONF_INITIAL_TRANSITION: 0,
+        CONF_TRANSITION: 0,
+        CONF_DETECT_NON_HA_CHANGES: True,
+        CONF_INTERCEPT: True,
+    }
+    _, switch1 = await setup_switch(
+        hass, {CONF_NAME: "switch1", CONF_LIGHTS: [ENTITY_LIGHT_1], **defaults},
+    )
+    _, switch2 = await setup_switch(
+        hass, {CONF_NAME: "switch2", CONF_LIGHTS: [ENTITY_LIGHT_2], **defaults},
+    )
+    assert hass.states.get(switch1.entity_id).state == STATE_ON
+    assert hass.states.get(switch2.entity_id).state == STATE_ON
+
+    # Mark the unmanaged light as a "service" light (entity_category set).
+    reg.async_update_entity(
+        ENTITY_LIGHT_3, entity_category=EntityCategory.CONFIG,
+    )
+    assert reg.async_get(ENTITY_LIGHT_3).entity_category == EntityCategory.CONFIG
+
+    # Ensure the lights start off so the area toggle turns them on.
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_AREA_ID: "test-area"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(ENTITY_LIGHT_1).state == STATE_OFF
+    assert hass.states.get(ENTITY_LIGHT_2).state == STATE_OFF
+    assert hass.states.get(ENTITY_LIGHT_3).state == STATE_OFF
+
+    # Toggle the whole area via the area target.
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TOGGLE,
+        {ATTR_AREA_ID: "test-area"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Managed lights are toggled on (and adapted) by AL's intercept.
+    assert hass.states.get(ENTITY_LIGHT_1).state == STATE_ON
+    assert hass.states.get(ENTITY_LIGHT_2).state == STATE_ON
+    # The service light is excluded by HA's area expansion AND by AL's
+    # re-issue filter, so it must remain off.
+    assert hass.states.get(ENTITY_LIGHT_3).state == STATE_OFF

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -3400,17 +3400,20 @@ async def test_service_light_turns_on_when_directly_targeted(hass):
         CONF_INTERCEPT: True,
     }
     _, switch1 = await setup_switch(
-        hass, {CONF_NAME: "switch1", CONF_LIGHTS: [ENTITY_LIGHT_1], **defaults},
+        hass,
+        {CONF_NAME: "switch1", CONF_LIGHTS: [ENTITY_LIGHT_1], **defaults},
     )
     _, switch2 = await setup_switch(
-        hass, {CONF_NAME: "switch2", CONF_LIGHTS: [ENTITY_LIGHT_2], **defaults},
+        hass,
+        {CONF_NAME: "switch2", CONF_LIGHTS: [ENTITY_LIGHT_2], **defaults},
     )
     assert hass.states.get(switch1.entity_id).state == STATE_ON
     assert hass.states.get(switch2.entity_id).state == STATE_ON
 
     # Mark the unmanaged light as a "service" light (entity_category set).
     reg.async_update_entity(
-        ENTITY_LIGHT_3, entity_category=EntityCategory.CONFIG,
+        ENTITY_LIGHT_3,
+        entity_category=EntityCategory.CONFIG,
     )
     assert reg.async_get(ENTITY_LIGHT_3).entity_category == EntityCategory.CONFIG
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -3326,17 +3326,20 @@ async def test_service_light_excluded_from_area_intercept_toggle(hass):
         CONF_INTERCEPT: True,
     }
     _, switch1 = await setup_switch(
-        hass, {CONF_NAME: "switch1", CONF_LIGHTS: [ENTITY_LIGHT_1], **defaults},
+        hass,
+        {CONF_NAME: "switch1", CONF_LIGHTS: [ENTITY_LIGHT_1], **defaults},
     )
     _, switch2 = await setup_switch(
-        hass, {CONF_NAME: "switch2", CONF_LIGHTS: [ENTITY_LIGHT_2], **defaults},
+        hass,
+        {CONF_NAME: "switch2", CONF_LIGHTS: [ENTITY_LIGHT_2], **defaults},
     )
     assert hass.states.get(switch1.entity_id).state == STATE_ON
     assert hass.states.get(switch2.entity_id).state == STATE_ON
 
     # Mark the unmanaged light as a "service" light (entity_category set).
     reg.async_update_entity(
-        ENTITY_LIGHT_3, entity_category=EntityCategory.CONFIG,
+        ENTITY_LIGHT_3,
+        entity_category=EntityCategory.CONFIG,
     )
     assert reg.async_get(ENTITY_LIGHT_3).entity_category == EntityCategory.CONFIG
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -111,6 +111,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
+    EntityCategory,
 )
 from homeassistant.const import __version__ as ha_version
 from homeassistant.core import Context, Event, HomeAssistant, State
@@ -3235,3 +3236,61 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
     assert (
         light.brightness == manual_brightness
     ), f"AL overrode manual brightness {manual_brightness} with {al_brightness}"
+
+
+async def test_service_light_excluded_from_area_intercept_turn_on(hass):
+    """A service light (entity_category set) in an area must stay off.
+
+    Regression test for #1510: when Adaptive Lighting intercepts an area
+    `light.turn_on`, it must not re-issue `turn_on` for entities that Home
+    Assistant itself excludes from area expansion (entities with an
+    `entity_category`, e.g. the Home Assistant Voice LED ring). The managed
+    lights must still turn on and be adapted.
+    """
+    await setup_lights(hass)
+    mock_area_registry(hass)
+
+    reg = entity_registry.async_get(hass)
+    for light in (ENTITY_LIGHT_1, ENTITY_LIGHT_2, ENTITY_LIGHT_3):
+        entry = reg.async_get(light)
+        reg.async_get_or_create(LIGHT_DOMAIN, "template", entry.unique_id)
+        reg.async_update_entity(light, area_id="test-area")
+
+    defaults = {
+        CONF_SUNRISE_TIME: datetime.time(SUNRISE.hour),
+        CONF_SUNSET_TIME: datetime.time(SUNSET.hour),
+        CONF_INITIAL_TRANSITION: 0,
+        CONF_TRANSITION: 0,
+        CONF_DETECT_NON_HA_CHANGES: True,
+        CONF_INTERCEPT: True,
+    }
+    _, switch1 = await setup_switch(
+        hass, {CONF_NAME: "switch1", CONF_LIGHTS: [ENTITY_LIGHT_1], **defaults},
+    )
+    _, switch2 = await setup_switch(
+        hass, {CONF_NAME: "switch2", CONF_LIGHTS: [ENTITY_LIGHT_2], **defaults},
+    )
+    assert hass.states.get(switch1.entity_id).state == STATE_ON
+    assert hass.states.get(switch2.entity_id).state == STATE_ON
+
+    # Mark the unmanaged light as a "service" light (entity_category set).
+    reg.async_update_entity(
+        ENTITY_LIGHT_3, entity_category=EntityCategory.CONFIG,
+    )
+    assert reg.async_get(ENTITY_LIGHT_3).entity_category == EntityCategory.CONFIG
+
+    # Turn on the whole area via the area target.
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_AREA_ID: "test-area"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Managed lights are turned on (and adapted) by AL's intercept.
+    assert hass.states.get(ENTITY_LIGHT_1).state == STATE_ON
+    assert hass.states.get(ENTITY_LIGHT_2).state == STATE_ON
+    # The service light is excluded by HA's area expansion AND by AL's
+    # re-issue filter, so it must remain off.
+    assert hass.states.get(ENTITY_LIGHT_3).state == STATE_OFF


### PR DESCRIPTION
Area-targeted `light.turn_on` and `light.toggle` calls could turn on hidden or categorized lights that Home Assistant excludes from the area target. Match those registry exclusions when Adaptive Lighting expands areas, while honoring explicit entity IDs and continuing to turn on unmanaged normal lights.

The change uses one area-only predicate and leaves the interceptor's existing skipped-light flow intact. Parameterized integration tests cover managed/unmanaged, area/direct, turn-on/toggle, and normal/config/diagnostic/hidden lights starting off. A pre-existing state-handler test now uses fixed adaptive brightness to avoid collisions with its manual test values.

Validation: 32 target-selection cases pass, the full 254-test integration suite passes on Home Assistant 2026.4.3 / Python 3.14.2, and repository pre-commit hooks pass.

Fixes #1510.
