### PR TITLE
ci: check out the workflow commit during test setup

### DIFF
--- a/.github/workflows/install_dependencies/action.yml
+++ b/.github/workflows/install_dependencies/action.yml
@@ -17,7 +17,7 @@ runs:
       uses: actions/checkout@v7
       with:
         repository: ${{ github.repository }}
-        ref: ${{ github.ref }}
+        ref: ${{ github.sha }}
         persist-credentials: false
         fetch-depth: 0
     - name: Check out code from GitHub


### PR DESCRIPTION
Test jobs can fail after a PR is merged because dependency setup fetches its deleted merge ref. Check out the workflow commit SHA so setup keeps testing the same commit as the initial checkout.

Verified against the checkout failure in [run 34020496672](https://github.com/basnijholt/adaptive-lighting/actions/runs/34020496672): the initial SHA fetch succeeded, then the ref fetch failed. Repository pre-commit hooks and `git diff --check` pass.
