### PR TITLE
fix: allow negative service offsets

### DIFF
--- a/custom_components/adaptive_lighting/services.yaml
+++ b/custom_components/adaptive_lighting/services.yaml
@@ -185,7 +185,7 @@ change_switch_settings:
       example: 0
       selector:
         number:
-          min: 0
+          min: -86400
           max: 86300
     sunrise_time:
       description: Set a fixed time (HH:MM:SS) for sunrise. 🌅
@@ -199,7 +199,7 @@ change_switch_settings:
       example: ''
       selector:
         number:
-          min: 0
+          min: -86400
           max: 86300
     sunset_time:
       description: Set a fixed time (HH:MM:SS) for sunset. 🌇


### PR DESCRIPTION
Allow negative sunrise and sunset offsets in the service editor. Both selector minima become -86400 seconds; runtime validation and existing upper bounds stay unchanged.

Checked both selectors against the supported signed runtime values; repository pre-commit hooks pass.

Fixes #1497.
