### PR TITLE
test: keep split-command brightness checks deterministic

### DIFF
--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1815,7 +1815,12 @@ async def test_separate_turn_on_commands(hass, separate_turn_on_commands):
     """Test 'separate_turn_on_commands' argument."""
     switch, (light, *_) = await setup_lights_and_switch(
         hass,
-        {CONF_SEPARATE_TURN_ON_COMMANDS: separate_turn_on_commands},
+        {
+            CONF_SEPARATE_TURN_ON_COMMANDS: separate_turn_on_commands,
+            # Keep normal brightness distinct from sleep mode at any time of day.
+            CONF_MIN_BRIGHTNESS: 50,
+            CONF_MAX_BRIGHTNESS: 50,
+        },
     )
     # We just turn sleep mode on and off which should change the
     # brightness and color. We don't test whether the number are exactly


### PR DESCRIPTION
At night, normal adaptive brightness can round to the same value as sleep brightness. The split-command test assumes those values differ, so both parameter cases fail depending on the clock.

Set normal brightness to 50% in this test's setup. Keep all existing brightness, color, and split-command assertions; runtime code is unchanged.

At the failing CI timestamp, both cases fail on current main and the pre-batch code, then pass with this fixture. Full Home Assistant 2026.4.3 suite: 270 passed. Repository hooks pass.
