### PR TITLE
docs: credit Weblate-only translators

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1368,6 +1368,33 @@
       "contributions": [
         "translation"
       ]
+    },
+    {
+      "login": "weblate-Lamster",
+      "name": "Allan Himidi-Rattenborg",
+      "avatar_url": "https://hosted.weblate.org/avatar/128/Lamster.png",
+      "profile": "https://hosted.weblate.org/user/Lamster/",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "login": "weblate-posemartonis",
+      "name": "Pose marto",
+      "avatar_url": "https://hosted.weblate.org/avatar/128/posemartonis.png",
+      "profile": "https://hosted.weblate.org/user/posemartonis/",
+      "contributions": [
+        "translation"
+      ]
+    },
+    {
+      "login": "weblate-jf.cosse",
+      "name": "Jean-Francois Cosse",
+      "avatar_url": "https://hosted.weblate.org/avatar/128/jf.cosse.png",
+      "profile": "https://hosted.weblate.org/user/jf.cosse/",
+      "contributions": [
+        "translation"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
 ![Version](https://img.shields.io/github/v/release/basnijholt/adaptive-lighting?style=for-the-badge)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-150-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-153-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 # 🌞 Adaptive Lighting: Enhance Your Home's Atmosphere with Smart, Sun-Synchronized Lighting 🌙
@@ -704,6 +704,9 @@ Notice the values of `brightness_mode_time_light` and `brightness_mode_time_dark
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/LukTyn"><img src="https://avatars.githubusercontent.com/u/1812796?v=4?s=100" width="100px;" alt="LukTyn"/><br /><sub><b>LukTyn</b></sub></a><br /><a href="#translation-LukTyn" title="Translation">🌍</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/rutgerkra"><img src="https://avatars.githubusercontent.com/u/7963187?v=4?s=100" width="100px;" alt="rutgerkra"/><br /><sub><b>rutgerkra</b></sub></a><br /><a href="#translation-rutgerkra" title="Translation">🌍</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/sergeybelozorov"><img src="https://avatars.githubusercontent.com/u/94930734?v=4?s=100" width="100px;" alt="sergeybelozorov"/><br /><sub><b>sergeybelozorov</b></sub></a><br /><a href="#translation-sergeybelozorov" title="Translation">🌍</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://hosted.weblate.org/user/Lamster/"><img src="https://hosted.weblate.org/avatar/128/Lamster.png?s=100" width="100px;" alt="Allan Himidi-Rattenborg"/><br /><sub><b>Allan Himidi-Rattenborg</b></sub></a><br /><a href="#translation-weblate-Lamster" title="Translation">🌍</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://hosted.weblate.org/user/posemartonis/"><img src="https://hosted.weblate.org/avatar/128/posemartonis.png?s=100" width="100px;" alt="Pose marto"/><br /><sub><b>Pose marto</b></sub></a><br /><a href="#translation-weblate-posemartonis" title="Translation">🌍</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://hosted.weblate.org/user/jf.cosse/"><img src="https://hosted.weblate.org/avatar/128/jf.cosse.png?s=100" width="100px;" alt="Jean-Francois Cosse"/><br /><sub><b>Jean-Francois Cosse</b></sub></a><br /><a href="#translation-weblate-jf.cosse" title="Translation">🌍</a></td>
     </tr>
   </tbody>
   <tfoot>


### PR DESCRIPTION
PR #1533 retained translations authored by three contributors whose source commits do not expose verified GitHub accounts. This credits their exact public Weblate identities with platform-prefixed registry IDs, Weblate profile links, and Weblate avatars.

The contributor CLI regenerated the README from .all-contributorsrc. Validation confirmed all 150 existing entries are unchanged, the three profiles appear once, and the badge and registry both report 153 contributors.

Validation: npx --yes all-contributors-cli generate; uv run pre-commit run --files .all-contributorsrc README.md.
