### PR TITLE
Set conservative coverage floors for supported Home Assistant versions

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -103,6 +103,15 @@ jobs:
             exit 1
           fi
 
+          if [[ "${CORE_VERSION}" != "dev" && "${PYTEST_OUTCOME}" == "success" ]]; then
+            echo "Required coverage: 89% lines and 80% branches." >> "${GITHUB_STEP_SUMMARY}"
+            if ! jq -e '.totals | .covered_lines * 100 >= .num_statements * 89
+              and .covered_branches * 100 >= .num_branches * 80' core/coverage.json > /dev/null; then
+              echo "::error::Coverage must be at least 89% lines and 80% branches."
+              exit 1
+            fi
+          fi
+
       - name: Upload coverage reports
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7.0.1

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,7 @@ Alternatively, you can use the provided Docker image to run the tests locally or
 
 ## Coverage reports
 
-Open a `pytest` workflow run in GitHub Actions to see line and branch coverage in each job's summary. Download its `coverage-<Home Assistant version>-py<Python version>` artifact for the XML and JSON reports and the browsable HTML report. After extracting it, open `htmlcov/index.html` to inspect missing lines and branches.
+Open a `pytest` workflow run in GitHub Actions to see line and branch coverage in each job's summary. Download its `coverage-<Home Assistant version>-py<Python version>` artifact for the XML and JSON reports and the browsable HTML report. After extracting it, open `htmlcov/index.html` to inspect missing lines and branches. Supported stable Home Assistant versions require at least 89% line coverage and 80% branch coverage. The `dev` job reports coverage without enforcing these floors.
 
 Coverage measures executed code, not whether assertions would catch a bug. Add tests for observable behavior: emitted light commands, final states, manual-control events, and timer expiry. The integration suite runs inside Home Assistant with simulated lights; it does not establish physical-device behavior. It also does not execute every documentation generator included in the package's coverage total.
 


### PR DESCRIPTION
Require 89% line coverage and 80% branch coverage for supported stable Home Assistant versions. The `dev` job still reports coverage, and its tests must still pass.

These floors leave room below the measured stable matrix minima (90.01% lines, 80.95% branches). The combined options UI and regression tests measure 90.23% lines and 81.66% branches. Counts are compared without rounding; package scope stays unchanged.

Validation: the exact summary script passed 21 checks using all 14 CI artifacts, threshold boundaries, missing reports, failed tests, and the dev exception. Repository hooks and actionlint passed.
