### PR TITLE
chore: release v1.32.0

### DIFF
--- a/custom_components/adaptive_lighting/manifest.json
+++ b/custom_components/adaptive_lighting/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/basnijholt/adaptive-lighting/issues",
   "requirements": ["ulid-transform"],
-  "version": "1.31.0"
+  "version": "1.32.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "adaptive-lighting"
-version = "1.30.1"
+version = "1.32.0"
 description = "Automatically adjust brightness and color of lights based on the sun position"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -71,7 +71,7 @@ wheels = [
 
 [[package]]
 name = "adaptive-lighting"
-version = "1.30.1"
+version = "1.32.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Bump Adaptive Lighting to 1.32.0 in the integration manifest, Python package metadata, and the lockfile's local package entry. No runtime code or dependency versions change.

Validated with `uv lock --check --offline`, `uv build`, pre-commit, and version checks against the built wheel and its manifest.
