### PR TITLE
docs: clarify persistent sleep mode and daytime dimming

### DIFF
--- a/docs/advanced/sleep-mode.md
+++ b/docs/advanced/sleep-mode.md
@@ -28,10 +28,11 @@ restart. Use an automation, such as the sleep-mode blueprint linked under
 Automation Examples, when you want the switch to follow a schedule or helper.
 
 If lights unexpectedly use `sleep_brightness` or `sleep_color_temp` during the
-day, first check that the sleep-mode switch is off. The main Adaptive Lighting
-switch reports the current calculated `brightness_pct` and `color_temp_kelvin`
-targets, including the sleep settings while sleep mode is on. You can compare
-these attributes with the physical light state. In debug logs,
+day, first check that the sleep-mode switch is off. While the main Adaptive
+Lighting switch is on, it reports the current calculated `brightness_pct` and
+`color_temp_kelvin` targets, including the sleep settings while sleep mode is on.
+You can compare these attributes with the physical light state. They are `None`
+when the main switch is off. In debug logs,
 `initial_sleep=True` describes an internal delay before sending a command; it does
 not mean that sleep mode is active.
 

--- a/docs/advanced/sleep-mode.md
+++ b/docs/advanced/sleep-mode.md
@@ -22,6 +22,19 @@ target:
   entity_id: switch.adaptive_lighting_sleep_mode_living_room
 ```
 
+Sleep mode stays active until this switch is turned off. It does not turn off
+automatically at sunrise, and Home Assistant restores its previous state after a
+restart. Use an automation, such as the sleep-mode blueprint linked under
+Automation Examples, when you want the switch to follow a schedule or helper.
+
+If lights unexpectedly use `sleep_brightness` or `sleep_color_temp` during the
+day, first check that the sleep-mode switch is off. The main Adaptive Lighting
+switch reports the current calculated `brightness_pct` and `color_temp_kelvin`
+targets, including the sleep settings while sleep mode is on. You can compare
+these attributes with the physical light state. In debug logs,
+`initial_sleep=True` describes an internal delay before sending a command; it does
+not mean that sleep mode is active.
+
 ## Configuration Options
 
 Sleep mode is configured through the main Adaptive Lighting configuration. See the [Configuration](../configuration.md) page for the full options table. The sleep-related options are:


### PR DESCRIPTION
Sleep mode can remain on during the day because its switch restores its previous state after a restart. The linked #1203 log shows that state being restored, and #1135 includes commands matching the configured sleep values.

Explain how to check the sleep switch and current targets, how to schedule it, and why `initial_sleep` in debug logs is unrelated. No runtime change; the mixed reports in #1135 still need individual confirmation on v1.32.0.

Validation: 467 tests passed on Home Assistant 2026.9.1, including existing sleep-state tests. Documentation build and pre-commit hooks passed.

Refs #1135 and #1203.
