### PR TITLE
test: preserve physical dimming across repeated turn-on calls

### DIFF
--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -5100,12 +5100,12 @@ async def test_adapt_only_on_bare_turn_on_respects_pause_changed_mode(hass, inte
 
 
 @pytest.mark.parametrize(
-    ("repeat_bare_turn_on", "mode", "intercept", "expected_color_temp"),
+    ("repeat_bare_turn_on", "mode", "intercept"),
     [
-        (False, TakeOverControlMode.PAUSE_ALL, False, 3000),
-        (False, TakeOverControlMode.PAUSE_CHANGED, False, 4000),
-        (True, TakeOverControlMode.PAUSE_ALL, True, 3000),
-        (True, TakeOverControlMode.PAUSE_CHANGED, True, 4000),
+        (False, TakeOverControlMode.PAUSE_ALL, False),
+        (False, TakeOverControlMode.PAUSE_CHANGED, False),
+        (True, TakeOverControlMode.PAUSE_ALL, True),
+        (True, TakeOverControlMode.PAUSE_CHANGED, True),
     ],
     ids=[
         "direct-pause-all-reactive",
@@ -5119,7 +5119,6 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(
     repeat_bare_turn_on,
     mode,
     intercept,
-    expected_color_temp,
 ):
     """Regression test for detect_non_ha_changes with separate_turn_on_commands.
 
@@ -5166,6 +5165,8 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(
 
     al_brightness = light.brightness
     assert al_brightness is not None
+    al_color_temp = light.color_temp_kelvin
+    assert al_color_temp is not None
     switch.manager.manual_control[ENTITY_LIGHT_1] = LightControlAttributes.NONE
 
     manual_brightness = (
@@ -5205,6 +5206,9 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(
     assert (
         light.brightness == manual_brightness
     ), f"AL overrode manual brightness {manual_brightness} with {light.brightness}"
+    expected_color_temp = (
+        4000 if mode == TakeOverControlMode.PAUSE_CHANGED else al_color_temp
+    )
     assert light.color_temp_kelvin == expected_color_temp
 
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -5099,7 +5099,28 @@ async def test_adapt_only_on_bare_turn_on_respects_pause_changed_mode(hass, inte
     )
 
 
-async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
+@pytest.mark.parametrize(
+    ("repeat_bare_turn_on", "mode", "intercept", "expected_color_temp"),
+    [
+        (False, TakeOverControlMode.PAUSE_ALL, False, 3000),
+        (False, TakeOverControlMode.PAUSE_CHANGED, False, 4000),
+        (True, TakeOverControlMode.PAUSE_ALL, True, 3000),
+        (True, TakeOverControlMode.PAUSE_CHANGED, True, 4000),
+    ],
+    ids=[
+        "direct-pause-all-reactive",
+        "direct-pause-changed-reactive",
+        "bare-turn-on-pause-all-intercept",
+        "bare-turn-on-pause-changed-intercept",
+    ],
+)
+async def test_detect_non_ha_changes_with_separate_turn_on_commands(
+    hass,
+    repeat_bare_turn_on,
+    mode,
+    intercept,
+    expected_color_temp,
+):
     """Regression test for detect_non_ha_changes with separate_turn_on_commands.
 
     With separate_turn_on_commands=True, each adaptation cycle makes two sequential
@@ -5107,6 +5128,9 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
     last_service_data instead of merging, brightness is dropped — and
     _attributes_have_changed silently skips the brightness comparison, so a direct
     Zigbee brightness change is never detected as manual control.
+
+    A repeated bare light.turn_on from an automation must not hide the physical
+    change before the periodic adaptation path runs.
     """
     switch, (light, *_) = await setup_lights_and_switch(
         hass,
@@ -5114,10 +5138,21 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
             CONF_SEPARATE_TURN_ON_COMMANDS: True,
             CONF_DETECT_NON_HA_CHANGES: True,
             CONF_TAKE_OVER_CONTROL: True,
+            CONF_TAKE_OVER_CONTROL_MODE: mode,
+            CONF_INTERCEPT: intercept,
         },
     )
 
-    context = switch.create_context("test")
+    _mock_sun_light_settings(
+        switch,
+        {
+            ATTR_BRIGHTNESS_PCT: 50,
+            ATTR_COLOR_TEMP_KELVIN: 3000,
+            "force_rgb_color": False,
+        },
+    )
+
+    context = switch.create_context("interval")
 
     async def update(force: bool = False):
         await switch._update_attrs_and_maybe_adapt_lights(
@@ -5129,15 +5164,6 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
 
     await update(force=True)
 
-    last_sd = switch.manager.last_service_data.get(ENTITY_LIGHT_1)
-    assert last_sd is not None, "last_service_data not set after force adapt"
-    assert (
-        ATTR_BRIGHTNESS in last_sd
-    ), f"brightness missing from last_service_data after split calls: {last_sd}"
-    assert (
-        ATTR_COLOR_TEMP_KELVIN in last_sd or ATTR_RGB_COLOR in last_sd
-    ), f"color missing from last_service_data after split calls: {last_sd}"
-
     al_brightness = light.brightness
     assert al_brightness is not None
     switch.manager.manual_control[ENTITY_LIGHT_1] = LightControlAttributes.NONE
@@ -5146,6 +5172,24 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
         al_brightness - 120 if al_brightness >= 120 else al_brightness + 120
     )
     set_light_brightness(light, manual_brightness)
+
+    if repeat_bare_turn_on:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: light.entity_id},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    _mock_sun_light_settings(
+        switch,
+        {
+            ATTR_BRIGHTNESS_PCT: 50,
+            ATTR_COLOR_TEMP_KELVIN: 4000,
+            "force_rgb_color": False,
+        },
+    )
 
     async def _flush_attr_state(hass, entity_id):
         """Mimic a ZHA attribute report: write current hardware state to HA."""
@@ -5156,20 +5200,12 @@ async def test_detect_non_ha_changes_with_separate_turn_on_commands(hass):
         new=AsyncMock(side_effect=_flush_attr_state),
     ):
         await update(force=False)
-
-        assert LightControlAttributes.BRIGHTNESS in switch.manager.manual_control.get(
-            ENTITY_LIGHT_1,
-            LightControlAttributes.NONE,
-        ), (
-            f"manual_control={switch.manager.manual_control.get(ENTITY_LIGHT_1)}, "
-            f"last_service_data={switch.manager.last_service_data.get(ENTITY_LIGHT_1)}"
-        )
-
         await update(force=False)
 
     assert (
         light.brightness == manual_brightness
-    ), f"AL overrode manual brightness {manual_brightness} with {al_brightness}"
+    ), f"AL overrode manual brightness {manual_brightness} with {light.brightness}"
+    assert light.color_temp_kelvin == expected_color_temp
 
 
 async def test_fresh_install_entity_ids(hass):


### PR DESCRIPTION
The split-command brightness tracking bug reported in #1070 was fixed in v1.32.0. Extend its regression test to cover physical dimming followed by a repeated bare `light.turn_on` from an automation before the next adaptation update.

Check that manual brightness is preserved, with color adapting only when the takeover mode permits it. This adds coverage for the reported interaction without changing runtime behavior. It does not establish that every hardware-specific report in #1070 is resolved.

Refs #1070 and #954.

Validation: all four focused cases and the full 470-test suite passed on Home Assistant 2026.9.1. Restoring the historical overwrite reproduced the failure: manual brightness changed from 8 to 128. Pre-commit hooks and independent review passed.

The four cases also pass on the minimum supported Home Assistant series (2025.9.4). The pause-all assertion compares with the light's actual initial color, accounting for mired conversion in older template lights.
