### PR TITLE
Make scripts/setup-symlinks idempotent

### DIFF
--- a/scripts/setup-symlinks
+++ b/scripts/setup-symlinks
@@ -2,12 +2,17 @@
 set -ex
 cd "$(dirname "$0")/.."
 
+# '-n' keeps a re-run idempotent: without it 'ln -fs' follows an existing
+# symlink and creates the new link *inside* the target directory, leaving a
+# stray 'tests/tests' and 'custom_components/adaptive_lighting/adaptive_lighting'
+# in the working tree.
+
 # Link custom components
 cd core/homeassistant/components/
-ln -fs ../../../custom_components/adaptive_lighting adaptive_lighting
+ln -fsn ../../../custom_components/adaptive_lighting adaptive_lighting
 cd -
 
 # Link tests
 cd core/tests/components/
-ln -fs ../../../tests/ adaptive_lighting
+ln -fsn ../../../tests/ adaptive_lighting
 cd -


### PR DESCRIPTION
`scripts/setup-symlinks` is not idempotent, which is easy to trip over because
`tests/README.md` presents it as a one-time setup step and nothing warns you if
you run it again.

`ln -fs` dereferences an existing symlink to a directory, so the second run
creates the new link *inside* the target rather than replacing it:

```console
$ ./scripts/setup-symlinks   # first run, from a clean checkout
$ git status --short         # clean

$ ./scripts/setup-symlinks   # second run
$ git status --short
?? custom_components/adaptive_lighting/adaptive_lighting
?? tests/tests
```

Neither stray path is gitignored, so a `git add -A` picks them up. That is how
they get committed — the two symlinks are small and easy to miss in a diff stat.

Adding `-n` makes `ln` treat an existing symlink as a file and replace it.

Verified by running the script three times in a row from a clean checkout: the
working tree stays clean, both symlinks still resolve, and the suite runs
through them unchanged (479 passed, plus this environment's usual 333
"Translation not found" errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
