### PR TITLE
Add a .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# The Home Assistant core checkout. tests/README.md has you clone it to ./core,
+# but the Dockerfile clones its own copy to /core and links /app/core to it.
+# Without this entry `COPY . /app/` ships ~300MB into every build and leaves
+# /app/core as a real directory, so `ln -s /core /app/core` links *inside* it
+# rather than creating the intended symlink.
+core/
+
+# Local virtualenvs
+.venv/
+venv/
+env/
+ENV/
+
+# Not used by the build
+.git/
+.vscode/
+.idea/
+
+# Caches and test output
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+htmlcov/
+.coverage
+.coverage.*
+coverage.xml


### PR DESCRIPTION
The repo has no `.dockerignore`, and Docker does not read `.gitignore`.

`tests/README.md` has developers clone Home Assistant core into `./core` before
running the Docker tests. `COPY . /app/` then ships that checkout — ~300MB — into
the build context and the image, on every build.

It also quietly changes what the build does. With `/app/core` present as a real
directory, this line does not do what it reads as:

```dockerfile
RUN ln -s /core /app/core && /app/scripts/setup-symlinks
```

`ln -s` descends into the existing directory and creates `/app/core/core -> /core`
instead of the intended `/app/core -> /core`:

```console
$ docker run --rm --entrypoint sh <image> -c 'ls -ld /app/core/core'
lrwxrwxrwx 1 root root 5 ... /app/core/core -> /core
```

`scripts/setup-dependencies` then resolves `core/requirements.txt` to the copied
host checkout rather than the image's own pinned clone, so that clone becomes
dead weight.

## Effect

| | before | after |
|---|---|---|
| build context | 412 MB | 4.6 MB |
| image | 2.34 GB | 2.1 GB |
| `/app/core` | real dir + stray `core/core` | symlink to `/core` |

A build with a local `./core` now behaves the same as a clean-checkout build.

## One behaviour change worth calling out

An image built while a local `./core` existed happened to run *without*
`-v $(pwd):/app`, because the copied checkout carried relative symlinks that
still resolved inside `/app`. That no longer holds.

It was an accident rather than a feature: a clean-checkout build never had it —
there the symlinks `setup-symlinks` writes into `/core` dangle, since
`../../../` from `/core/tests/components/` is `/`, not `/app/` — and
`tests/README.md` requires the mount either way ("Mount the entire repo
(`-v $(pwd):/app`), not individual directories, or the symlinks will break").

## Verification

Rebuilt from scratch, then `docker run --rm -v "$(pwd)":/app <image>
tests/components/adaptive_lighting`: **479 passed, 0 failed**, plus this
environment's usual 333 pre-existing "Translation not found" errors — identical
to before the change. Confirmed in the new image that `/app/core` is a symlink to
`/core` and `/app/core/core` no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
